### PR TITLE
i split alpine-base-nodejs in alpine-base-nodejs (no service) and alp…

### DIFF
--- a/alpine-base-nodejs/Dockerfile
+++ b/alpine-base-nodejs/Dockerfile
@@ -2,12 +2,10 @@ FROM unocha/alpine-base-s6:latest
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
-COPY node-run /tmp/
+ENV NODE_APP_DIR=/srv/www \
+    SRC_DIR=/src
 
-ENV NODE_APP_DIR /srv/www
-
-RUN apk update && \
-    apk add --update \
+RUN apk add --update \
         git \
         nodejs-lts \
         && \
@@ -16,9 +14,9 @@ RUN apk update && \
         grunt-cli \
         bower \
         && \
-    mkdir -p /srv/www /etc/services.d/node && \
-    mv /tmp/node-run /etc/services.d/node/run
+    mkdir -p ${SRC_DIR} ${NODE_APP_DIR}
 
-EXPOSE 3000
+VOLUME ["${SRC_DIR}", "${NODE_APP_DIR}"]
 
-VOLUME ["/srv/www"]
+# mainly used to build stuff so it makes sense to use ${SRC_DIR} as WORKDIR
+WORKDIR ${SRC_DIR}

--- a/alpine-base-nodejs/node-run
+++ b/alpine-base-nodejs/node-run
@@ -1,9 +1,0 @@
-#!/usr/bin/with-contenv sh
-
-cd $NODE_APP_DIR
-
-echo "==> Installing npm dependencies"
-npm install
-
-echo "==> Starting the server"
-exec npm start

--- a/alpine-base-nodejs/server.js
+++ b/alpine-base-nodejs/server.js
@@ -1,9 +1,0 @@
-var http = require('http');
-
-var server = http.createServer(function(req, res) {
-  res.end('Yep. It\'s working.\n');
-  // console.log('Test successful!');
-})
-
-server.listen(3000, '0.0.0.0');
-console.log("NodeJS web server running on 0.0.0.0:3000");


### PR DESCRIPTION
…ine-nodejs with the service.

This is needed for properties using grunt / npm / nodejs to build their apps.

The new alpine-base-nodejs will only be used for building, while alpine-nodejs for serving up the compiled app.
