### PR TITLE
fix OPS-978.

### DIFF
--- a/alpine-nginx-extras/run_nginx
+++ b/alpine-nginx-extras/run_nginx
@@ -1,4 +1,2 @@
-#!/bin/sh
-set -e
-cd /etc/nginx
-exec /usr/sbin/nginx -c /etc/nginx/nginx.conf
+#!/usr/bin/execlineb -P
+exec nginx -g "daemon off";


### PR DESCRIPTION
In the vast majority of our configuration files for nginx, there is no "daemon off" config line.

The nginx started previously in the background instead of foreground (as required by docker).

A second nginx process would start and throw those errors.

I added the "daemon off" option in the startup script so that we wont need to alter our config files.
