### PR TITLE
Ensure apk cache is cleared

### DIFF
--- a/alpine-base-jdk/7/Dockerfile
+++ b/alpine-base-jdk/7/Dockerfile
@@ -15,10 +15,10 @@ ENV JAVA_VERSION_MAJOR=7 \
     LANG=C.UTF-8
 
 # do all in one step
-RUN apk upgrade --update && \
-    apk add --update curl ca-certificates bash && \
+RUN apk upgrade --update-cache && \
+    apk add --update-cache curl ca-certificates bash && \
     for pkg in glibc-2.23-r1 glibc-bin-2.23-r1 glibc-i18n-2.23-r1; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-    apk add --allow-untrusted /tmp/*.apk && \
+    apk add --update-cache --allow-untrusted /tmp/*.apk && \
     rm -v /tmp/*.apk && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \

--- a/alpine-base-jdk/8/Dockerfile
+++ b/alpine-base-jdk/8/Dockerfile
@@ -16,10 +16,10 @@ ENV JAVA_VERSION_MAJOR=8 \
     LANG=C.UTF-8
 
 # do all in one step
-RUN apk upgrade --update && \
-    apk add --update curl ca-certificates bash && \
+RUN apk upgrade --update-cache && \
+    apk add --update-cache curl ca-certificates bash && \
     for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-    apk add --allow-untrusted /tmp/*.apk && \
+    apk add --update-cache --allow-untrusted /tmp/*.apk && \
     rm -v /tmp/*.apk && \
     ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \

--- a/alpine-base-mongo/Dockerfile
+++ b/alpine-base-mongo/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 ENV LANG=en_US.utf8
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
-    apk add --update --no-cache \
+    apk add --update-cache \
         mongodb \
-        mongodb-tools
+        mongodb-tools \
+        && \
+    rm -rf /var/cache/apk/*

--- a/alpine-base-mysql/Dockerfile
+++ b/alpine-base-mysql/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 ENV LANG=en_US.utf8
 
-RUN apk add --update \
+RUN apk add --update-cache \
         mysql \
         mysql-client \
         && \
-    rm -rf /var/lib/apk/*
+    rm -rf /var/cache/apk/*

--- a/alpine-base-nginx-extras/Dockerfile
+++ b/alpine-base-nginx-extras/Dockerfile
@@ -11,7 +11,7 @@ ENV NGINX_UPLOADPROGRESS_VERSION v0.9.1
 
 RUN build_pkgs="build-base linux-headers openssl-dev pcre-dev wget zlib-dev" \
   && runtime_pkgs="ca-certificates openssl pcre zlib" \
-  && apk --update add ${build_pkgs} ${runtime_pkgs} \
+  && apk add --update-cache ${build_pkgs} ${runtime_pkgs} \
   && cd /tmp \
   && wget -q https://github.com/masterzen/nginx-upload-progress-module/archive/${NGINX_UPLOADPROGRESS_VERSION}.zip \
   && unzip ${NGINX_UPLOADPROGRESS_VERSION}.zip \

--- a/alpine-base-nginx/Dockerfile
+++ b/alpine-base-nginx/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 COPY nginx.conf default.conf index.html run_nginx /
 
 # Install nginx.
-RUN apk --update add \
+RUN apk add --update-cache \
       nginx \
  && rm -rf /var/cache/apk/* \
  && mkdir -p /etc/services.d/nginx /srv/www/html /var/log/nginx /var/cache/nginx \

--- a/alpine-base-nodejs/Dockerfile
+++ b/alpine-base-nodejs/Dockerfile
@@ -5,11 +5,11 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 ENV NODE_APP_DIR=/srv/www \
     SRC_DIR=/src
 
-RUN apk add --update \
+RUN apk add --update-cache \
         git \
         nodejs-lts \
         && \
-    rm -rf /var/lib/apk/* && \
+    rm -rf /var/cache/apk/* && \
     npm install -g \
         grunt-cli \
         bower \

--- a/alpine-base-php-fpm/3.3/Dockerfile
+++ b/alpine-base-php-fpm/3.3/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 COPY php-fpm.conf run_fpm /
 
 RUN apk update && \
-    apk add \
+    apk add --update-cache \
       php-bcmath \
       php-bz2 \
       php-ctype \

--- a/alpine-base-php-fpm/3.4/Dockerfile
+++ b/alpine-base-php-fpm/3.4/Dockerfile
@@ -11,7 +11,7 @@ RUN mv /usr/bin/import /usr/bin/s6-import
 COPY php-fpm.conf run_fpm msmtprc /
 
 RUN apk update && \
-    apk add \
+    apk add --update-cache \
       msmtp \
       php5-bcmath \
       php5-bz2 \

--- a/alpine-base-postgis/Dockerfile
+++ b/alpine-base-postgis/Dockerfile
@@ -3,9 +3,9 @@ FROM unocha/alpine-base-postgres:latest
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 ENV POSTGIS_VERSION 2.2.2
- 
+
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-    apk add --update --no-cache \
+    apk add --update-cache \
         postgresql-dev \
         perl \
         file \
@@ -26,11 +26,12 @@ RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/re
     ./configure && \
     echo "PERL = /usr/bin/perl" >> extensions/postgis/Makefile && \
     echo "PERL = /usr/bin/perl" >> extensions/postgis_topology/Makefile && \
-    make -s && \ 
+    make -s && \
     make -s install  && \
     cd / && \
     rm -rf /tmp/postgis-${POSTGIS_VERSION} && \
     apk del postgresql-dev perl file geos-dev \
             libxml2-dev gdal-dev proj4-dev \
-            gcc make libgcc g++
+            gcc make libgcc g++ && \
+    rm -rf /var/cache/apk/*
 

--- a/alpine-base-postgres/Dockerfile
+++ b/alpine-base-postgres/Dockerfile
@@ -7,12 +7,12 @@ ENV LANG=en_US.utf8 \
 
 COPY run_postgres /
 
-RUN apk add --update \
+RUN apk add --update-cache \
         postgresql \
         postgresql-client \
         postgresql-contrib \
         && \
-    rm -rf /var/lib/apk/* && \
+    rm -rf /var/cache/apk/* && \
     mkdir -p /etc/services.d/postgres && \
     mv /run_postgres /etc/services.d/postgres/run
 

--- a/alpine-base-python3/Dockerfile
+++ b/alpine-base-python3/Dockerfile
@@ -2,10 +2,10 @@ FROM unocha/alpine-base:latest
 
 MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
 
-RUN apk add --no-cache \
+RUN apk add --update-cache \
         python3 && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
     pip3 install --upgrade pip setuptools && \
     rm -r /root/.cache && \
-    rm -rf /var/lib/apk/*
+    rm -rf /var/cache/apk/*

--- a/alpine-base-redis/Dockerfile
+++ b/alpine-base-redis/Dockerfile
@@ -3,5 +3,5 @@ FROM unocha/alpine-base-s6:latest
 MAINTAINER "Serban TEODORESCU <teodorescu.serban@gmail.com>"
 
 RUN apk update && \
-    apk add redis && \
-    rm -rf /var/lib/apk/*
+    apk add --update-cache redis && \
+    rm -rf /var/cache/apk/*

--- a/alpine-base-s6-python3/Dockerfile
+++ b/alpine-base-s6-python3/Dockerfile
@@ -2,10 +2,10 @@ FROM unocha/alpine-base-s6:latest
 
 MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
 
-RUN apk add --update --no-cache \
+RUN apk add --update-cache \
         python3 && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
     pip3 install --upgrade pip setuptools && \
     rm -r /root/.cache && \
-    rm -rf /var/lib/apk/*
+    rm -rf /var/cache/apk/*

--- a/alpine-base/3.3/Dockerfile
+++ b/alpine-base/3.3/Dockerfile
@@ -8,8 +8,8 @@ ENV APPUSER_GID=4000 \
     APPUSER_UID=4000
 
 RUN apk update && \
-    apk add curl \
+    apk add --update-cache curl \
         nano && \
-    rm -rf /var/lib/apk/* && \
+    rm -rf /var/cache/apk/* && \
     addgroup -g $APPUSER_GID -S appuser && \
     adduser -u $APPUSER_UID -s /sbin/nologin -g 'Docker App User' -h /home/appuser -D -G appuser appuser

--- a/alpine-base/3.4/Dockerfile
+++ b/alpine-base/3.4/Dockerfile
@@ -8,8 +8,8 @@ ENV APPUSER_GID=4000 \
     APPUSER_UID=4000
 
 RUN apk update && \
-    apk add curl \
+    apk add --update-cache curl \
         nano && \
-    rm -rf /var/lib/apk/* && \
+    rm -rf /var/cache/apk/* && \
     addgroup -g $APPUSER_GID -S appuser && \
     adduser -u $APPUSER_UID -s /sbin/nologin -g 'Docker App User' -h /home/appuser -D -G appuser appuser

--- a/alpine-base/Dockerfile
+++ b/alpine-base/Dockerfile
@@ -8,8 +8,8 @@ ENV APPUSER_GID=4000 \
     APPUSER_UID=4000
 
 RUN apk update && \
-    apk add curl \
+    apk add --update-cache curl \
         nano && \
-    rm -rf /var/lib/apk/* && \
+    rm -rf /var/cache/apk/* && \
     addgroup -g $APPUSER_GID -S appuser && \
     adduser -u $APPUSER_UID -s /sbin/nologin -g 'Docker App User' -h /home/appuser -D -G appuser appuser

--- a/alpine-filebeat/Dockerfile
+++ b/alpine-filebeat/Dockerfile
@@ -9,7 +9,7 @@ ENV LANG=en_US.utf8 \
 
 COPY run_filebeat filebeat* /
 
-RUN apk --update --no-cache add curl && \
+RUN apk add --update-cache curl && \
     curl https://download.elastic.co/beats/filebeat/filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz -o /filebeat.tar.gz && \
     echo "${FILEBEAT_SHA1}  filebeat.tar.gz" | sha1sum -c - && \
     tar xzvf filebeat.tar.gz && \
@@ -21,6 +21,7 @@ RUN apk --update --no-cache add curl && \
     cd / && \
     rm -rf filebeat* && \
     mkdir -p /etc/services.d/filebeat && \
-    mv /run_filebeat /etc/services.d/filebeat/run
+    mv /run_filebeat /etc/services.d/filebeat/run && \
+    rm -rf /var/cache/apk/*
 
 VOLUME ["/mnt"]

--- a/alpine-memcache/Dockerfile
+++ b/alpine-memcache/Dockerfile
@@ -10,10 +10,10 @@ ENV LANG=en_US.utf8 \
 
 COPY run_memcache /
 
-RUN apk add --update \
+RUN apk add --update-cache \
         memcached \
         && \
-    rm -rf /var/lib/apk/* && \
+    rm -rf /var/cache/apk/* && \
     mkdir -p /etc/services.d/memcache && \
     mv /run_memcache /etc/services.d/memcache/run
 

--- a/alpine-php-builder/Dockerfile
+++ b/alpine-php-builder/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER orakili <docker@orakili.net>
 # Alpine based docker image.
 # Includes php composer and ruby bundler.
 
-RUN apk -U --no-cache add \
+RUN apk add --update-cache \
       curl \
       git \
       gzip \
@@ -35,6 +35,7 @@ RUN apk -U --no-cache add \
       ruby-io-console \
       ruby-rdoc \
       ruby-json \
+ && rm -rf /var/cache/apk/* \
  && curl -sS https://getcomposer.org/installer \
       | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/alpine-php-fpm-drupal7-ghosts/3.4-newrelic/Dockerfile
+++ b/alpine-php-fpm-drupal7-ghosts/3.4-newrelic/Dockerfile
@@ -8,7 +8,7 @@ RUN sed -i s/4000/48/g /etc/group && \
 RUN cat /etc/passwd
 
 RUN apk update && \
-  apk add \
+  apk add --update-cache \
     php5-calendar \
     php5-exif \
     php5-ftp \
@@ -20,7 +20,7 @@ RUN apk update && \
   rm -rf /var/cache/apk/*
 
 RUN apk update && \
-  apk add \
+  apk add --update-cache \
     git \
     php5-dev \
     autoconf \
@@ -52,10 +52,11 @@ RUN apk update && \
   rm -rf /var/cache/apk/*
 
 # Add depends for capsper and phantom.
-RUN apk -U --no-cache add \
+RUN apk --update-cache add \
       fontconfig \
       libc6-compat \
-      python
+      python && \
+  rm -rf /var/cache/apk/*
 
 RUN curl -L -o /tmp/casperjs.zip https://github.com/n1k0/casperjs/archive/master.zip && \
     mkdir /opt && \

--- a/alpine-php-fpm-drupal7-ghosts/3.4/Dockerfile
+++ b/alpine-php-fpm-drupal7-ghosts/3.4/Dockerfile
@@ -8,7 +8,7 @@ RUN sed -i s/4000/48/g /etc/group && \
 RUN cat /etc/passwd
 
 RUN apk update && \
-  apk add \
+  apk add --update-cache \
     php5-calendar \
     php5-exif \
     php5-ftp \
@@ -20,7 +20,7 @@ RUN apk update && \
   rm -rf /var/cache/apk/*
 
 RUN apk update && \
-  apk add \
+  apk add --update-cache \
     git \
     php5-dev \
     autoconf \
@@ -52,10 +52,11 @@ RUN apk update && \
   rm -rf /var/cache/apk/*
 
 # Add depends for capsper and phantom.
-RUN apk -U --no-cache add \
+RUN apk --update-cache add \
       fontconfig \
       libc6-compat \
-      python
+      python && \
+  rm -rf /var/cache/apk/*
 
 RUN curl -L -o /tmp/casperjs.zip https://github.com/n1k0/casperjs/archive/master.zip && \
     mkdir /opt && \

--- a/alpine-php-fpm-drupal7/3.3/Dockerfile
+++ b/alpine-php-fpm-drupal7/3.3/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 ENV COMPOSER_HASH e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae
 
 RUN apk update && \
-    apk add \
+    apk add --update-cache \
       php-cli \
       mysql-client \
       postgresql-client  && \

--- a/alpine-php-fpm-drupal7/3.4/Dockerfile
+++ b/alpine-php-fpm-drupal7/3.4/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 ENV COMPOSER_HASH e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae
 
 RUN apk update && \
-    apk add \
+    apk add --update-cache \
       php5-cli \
       mysql-client \
       postgresql-client  && \

--- a/alpine-solr/6/Dockerfile
+++ b/alpine-solr/6/Dockerfile
@@ -11,7 +11,7 @@ ENV JDBC_PSQL_VERSION 9.4.1207
 
 COPY init-demo-core.sh run-solr /
 
-RUN apk add --update \
+RUN apk add --update-cache \
         bash \
         curl && \
     cd /tmp && \
@@ -32,7 +32,8 @@ RUN apk add --update \
     mkdir /etc/services.d/solr && \
     mv /run-solr /etc/services.d/solr/run && \
     sed -i 's/INFO/WARN/' /srv/solr/server/resources/log4j.properties && \
-    chmod +x /init-demo-core.sh
+    chmod +x /init-demo-core.sh && \
+    rm -rf /var/cache/apk/*
 
 EXPOSE 8983
 

--- a/alpine-wkhtmltopdf/Dockerfile
+++ b/alpine-wkhtmltopdf/Dockerfile
@@ -2,7 +2,7 @@ FROM unocha/alpine-nodejs:latest
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
-RUN apk add --no-cache --update \
+RUN apk add --update-cache \
         xvfb \
         ttf-freefont \
         fontconfig && \
@@ -10,8 +10,9 @@ RUN apk add --no-cache --update \
             --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
             --allow-untrusted \
         wkhtmltopdf && \
-    apk add --no-cache --update \
+    apk add --update-cache \
         python \
         make \
         g++ && \
-    npm install wkhtmltox
+    npm install wkhtmltox && \
+    rm -rf /var/cache/apk/*


### PR DESCRIPTION
This PR attempts to standardize the `apk add` commands and ensure that the cache is cleared.

There are still some `apk update` that are not necessary I think.

Also, with or without this patch, I couldn't build the `alpine-solr/6` image:

```
getting solr 6.0.1
gzip: invalid magic
tar: short read
sed: /srv/solr/server/resources/log4j.properties: No such file or directory
```

cc @teodorescuserban @cafuego 
