### PR TITLE
[OPS-987] Build PHP 5.6.26 FPM containers.

### DIFF
--- a/alpine-base-php-fpm/3.4/Dockerfile
+++ b/alpine-base-php-fpm/3.4/Dockerfile
@@ -4,6 +4,21 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 # Thanks to orakili <docker@orakili.net>
 
+# A little bit of metadata management.
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version="5.6.26" \
+      org.label-schema.name="base-php-fpm" \
+      org.label-schema.description="This service provides a base php-fpm platform." \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF
+
 # Work around s6 containing a binary called `import' which
 # clashes with imagemagick. D'oh.
 RUN mv /usr/bin/import /usr/bin/s6-import

--- a/alpine-php-fpm-drupal7-ghosts/3.4-newrelic/Dockerfile
+++ b/alpine-php-fpm-drupal7-ghosts/3.4-newrelic/Dockerfile
@@ -1,5 +1,14 @@
 FROM unocha/alpine-php-fpm-drupal7:3.4-newrelic
 
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version="5.6.26" \
+      org.label-schema.name="php-fpm-drupal7-ghosts" \
+      org.label-schema.description="This service provides a php-fpm platform with New Relic for the FTS Drupal 7." \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN sed -i s/4000/48/g /etc/group && \
     sed -i s/4000/48/g /etc/group- && \
     sed -i s/4000/48/g /etc/passwd && \

--- a/alpine-php-fpm-drupal7-ghosts/3.4/Dockerfile
+++ b/alpine-php-fpm-drupal7-ghosts/3.4/Dockerfile
@@ -1,5 +1,14 @@
 FROM unocha/alpine-php-fpm-drupal7:3.4
 
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version="5.6.26" \
+      org.label-schema.name="php-fpm-drupal7-ghosts" \
+      org.label-schema.description="This service provides a php-fpm platform for the FTS Drupal 7." \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN sed -i s/4000/48/g /etc/group && \
     sed -i s/4000/48/g /etc/group- && \
     sed -i s/4000/48/g /etc/passwd && \

--- a/alpine-php-fpm-drupal7-hrinfo/3.4-newrelic/Dockerfile
+++ b/alpine-php-fpm-drupal7-hrinfo/3.4-newrelic/Dockerfile
@@ -2,6 +2,15 @@ FROM unocha/alpine-php-fpm-drupal7:3.4-newrelic
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version="5.6.26" \
+      org.label-schema.name="php-fpm-drupal7-hrinfo" \
+      org.label-schema.description="This service provides a php-fpm platform with New Relic for the humanitarianresponse.info Drupal 7." \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN sed -i s/4000/518/g /etc/group && \
     sed -i s/4000/518/g /etc/group- && \
     sed -i s/4000/518/g /etc/passwd && \

--- a/alpine-php-fpm-drupal7-hrinfo/3.4/Dockerfile
+++ b/alpine-php-fpm-drupal7-hrinfo/3.4/Dockerfile
@@ -2,6 +2,15 @@ FROM unocha/alpine-php-fpm-drupal7:3.4
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version="5.6.26" \
+      org.label-schema.name="php-fpm-drupal7-hrinfo" \
+      org.label-schema.description="This service provides a php-fpm platform for the humanitarianresponse.info Drupal 7." \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN sed -i s/4000/518/g /etc/group && \
     sed -i s/4000/518/g /etc/group- && \
     sed -i s/4000/518/g /etc/passwd && \

--- a/alpine-php-fpm-drupal7/3.4-newrelic/Dockerfile
+++ b/alpine-php-fpm-drupal7/3.4-newrelic/Dockerfile
@@ -4,7 +4,16 @@ MAINTAINER Peter Lieverdink <peterl@humanitarianresponse.info>
 
 # Thanks to orakili <docker@orakili.net>
 
-ENV NR_VERSION php5-6.6.1.172-linux-musl
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version="5.6.26" \
+      org.label-schema.name="php-fpm-drupal7-nr" \
+      org.label-schema.description="This service provides a php-fpm platform with New Relic for Drupal 7 with Drush and composer." \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF
+
+ENV NR_VERSION php5-6.7.0.174-linux-musl
 
 COPY run_newrelic /
 

--- a/alpine-php-fpm-drupal7/3.4/Dockerfile
+++ b/alpine-php-fpm-drupal7/3.4/Dockerfile
@@ -4,6 +4,21 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 # Thanks to orakili <docker@orakili.net>
 
+# A little bit of metadata management.
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version="5.6.26" \
+      org.label-schema.name="php-fpm-drupal7" \
+      org.label-schema.description="This service provides a php-fpm platform for Drupal 7 with Drush and composer." \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF
+
 ENV COMPOSER_HASH e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae
 
 RUN apk update && \


### PR DESCRIPTION
- Rebuild containers with updated PHP 5.6.26.
- Update New Relic to the current version.
- Add container metadata.
