### PR TITLE
Cleanup - alpine-solr

### DIFF
--- a/alpine-solr/4/Dockerfile
+++ b/alpine-solr/4/Dockerfile
@@ -2,11 +2,11 @@ FROM unocha/alpine-jdk:8
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
-ENV SOLR_VERSION="4.10.4" \
-    SOLR="solr-4.10.4" \
-    JDBC_MYSQL_VERSION="5.1.38" \
-    JDBC_PSQL_VERSION="9.4.1207" \
-    SOLR_HEAP_SIZE="512m"
+ENV SOLR_VERSION=4.10.4 \
+    SOLR=solr-4.10.4 \
+    JDBC_MYSQL_VERSION=5.1.38 \
+    JDBC_PSQL_VERSION=9.4.1207 \
+    SOLR_HEAP_SIZE=512m
 
 COPY run-solr /
 
@@ -27,7 +27,7 @@ RUN apk add --update \
     gzip -dc /tmp/mysql-connector-java-$JDBC_MYSQL_VERSION.tar.gz | tar -x -T /tmp/include > /srv/solr/dist/mysql-connector-java-$JDBC_MYSQL_VERSION-bin.jar && \
     echo "cleaning up.." >&2 && \
     apk del curl || true && \
-    rm -rf /tmp/* && \
+    rm -rf /tmp/* /var/cache/apk/* && \
     echo "setting log level to warn.." && \
     sed -i 's/INFO/WARN/' /srv/solr/example/resources/log4j.properties && \
     echo "creating solr service.." && \

--- a/alpine-solr/6/Dockerfile
+++ b/alpine-solr/6/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 # Thanks to Anastas Dancha "anapsix@random.io"
 
-ENV SOLR_VERSION 6.0.1
-ENV SOLR solr-$SOLR_VERSION
-ENV JDBC_MYSQL_VERSION 5.1.38
-ENV JDBC_PSQL_VERSION 9.4.1207
+ENV SOLR_VERSION=6.0.1 \
+    SOLR=solr-6.0.1 \
+    JDBC_MYSQL_VERSION=5.1.38 \
+    JDBC_PSQL_VERSION=9.4.1207
 
 COPY init-demo-core.sh run-solr /
 
@@ -16,7 +16,7 @@ RUN apk add --update-cache \
         curl && \
     cd /tmp && \
     echo "getting solr $SOLR_VERSION" >&2 && \
-    curl -sSL http://mirrors.gigenet.com/apache/lucene/solr/$SOLR_VERSION/$SOLR.tgz -o /tmp/$SOLR.tgz && \
+    curl -sSL http://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/$SOLR.tgz -o /tmp/$SOLR.tgz && \
     mkdir -p /srv && \
     gzip -dc /tmp/$SOLR.tgz | tar -C /srv -x && \
     ln -sf /srv/$SOLR /srv/solr && \
@@ -28,12 +28,11 @@ RUN apk add --update-cache \
     gzip -dc /tmp/mysql-connector-java-$JDBC_MYSQL_VERSION.tar.gz | tar -x -T /tmp/include > /srv/solr/dist/mysql-connector-java-$JDBC_MYSQL_VERSION-bin.jar && \
     echo "cleaning up.." >&2 && \
     apk del curl || true && \
-    rm -rf /tmp/* && \
+    rm -rf /tmp/* /var/cache/apk/* && \
     mkdir /etc/services.d/solr && \
     mv /run-solr /etc/services.d/solr/run && \
     sed -i 's/INFO/WARN/' /srv/solr/server/resources/log4j.properties && \
-    chmod +x /init-demo-core.sh && \
-    rm -rf /var/cache/apk/*
+    chmod +x /init-demo-core.sh
 
 EXPOSE 8983
 


### PR DESCRIPTION
- Regroup ENV to reduce number of layers and make the syntax consistent with docker files.
- Change download URL for solr6 because it was broken due to newer version of solr.

@teodorescuserban re. version of solr, the latest one is 6.2.1 but the image uses 6.0.1.
