### PR TITLE
Cleanup - alpine-php-fpm-drupal7

### DIFF
--- a/alpine-php-fpm-drupal7/3.3/Dockerfile
+++ b/alpine-php-fpm-drupal7/3.3/Dockerfile
@@ -4,28 +4,28 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 # Thanks to orakili <docker@orakili.net>
 
-ENV COMPOSER_HASH e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae
+ENV DRUSH_VERSION=7 \
+    DRUSH_RELEASE=7.4.0
 
-RUN apk update && \
-    apk add --update-cache \
+RUN apk add --update-cache \
       php-cli \
       mysql-client \
       postgresql-client  && \
-    rm -rf /var/cache/apk/*
-
-# Set unlimited memory for CLI php.
-RUN sed -i 's/^memory_limit = .*/memory_limit = -1/' /etc/php/php.ini
-
-# Install composer, as suggested by https://getcomposer.org/
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+    rm -rf /var/cache/apk/* && \
+    # Set unlimited memory for CLI php.
+    sed -i 's/^memory_limit = .*/memory_limit = -1/' /etc/php/php.ini && \
+    # Install composer, as suggested by https://getcomposer.org/
+    # and https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+    COMPOSER_HASH=$(curl -sS https://composer.github.io/installer.sig) && \
+    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
     php -r "if (hash_file('SHA384', 'composer-setup.php') === '$COMPOSER_HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
     php composer-setup.php --install-dir=/usr/bin --filename=composer && \
-    php -r "unlink('composer-setup.php');"
-
-# Install drush and symlink it somewhere useful.
-RUN COMPOSER_HOME=/usr/local/drush6 \
-    composer global require drush/drush 6.x
-RUN ln -sf /usr/local/drush6/vendor/bin/drush /usr/bin/drush
+    php -r "unlink('composer-setup.php');" && \
+    # Install drush and symlink it somewhere useful.
+    COMPOSER_HOME=/usr/local/drush$DRUSH_VERSION \
+      composer global require drush/drush:$DRUSH_RELEASE && \
+    ln -sf /usr/local/drush$DRUSH_VERSION/vendor/bin/drush /usr/bin/drush && \
+    drush status
 
 # Volumes
 # - Conf: /etc/php/ (php-fpm.conf, php.ini)

--- a/alpine-php-fpm-drupal7/3.3/Dockerfile
+++ b/alpine-php-fpm-drupal7/3.3/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 # Thanks to orakili <docker@orakili.net>
 
-ENV DRUSH_VERSION=7 \
-    DRUSH_RELEASE=7.4.0
+ENV DRUSH_VERSION=6 \
+    DRUSH_RELEASE=6.7.0
 
 RUN apk add --update-cache \
       php-cli \

--- a/alpine-php-fpm-drupal7/3.4-newrelic/Dockerfile
+++ b/alpine-php-fpm-drupal7/3.4-newrelic/Dockerfile
@@ -18,9 +18,8 @@ ENV NR_VERSION php5-6.7.0.174-linux-musl
 COPY run_newrelic /
 
 RUN curl -s -o /tmp/newrelic.tar.gz \
-      https://download.newrelic.com/php_agent/release/newrelic-$NR_VERSION.tar.gz
-
-RUN mkdir -p /etc/newrelic /var/log/newrelic && \
+      https://download.newrelic.com/php_agent/release/newrelic-$NR_VERSION.tar.gz && \
+    mkdir -p /etc/newrelic /var/log/newrelic && \
     tar xvf /tmp/newrelic.tar.gz -C /tmp && \
     mv /tmp/newrelic-$NR_VERSION/daemon/newrelic-daemon.x64 \
        /usr/bin/newrelic-daemon && \
@@ -30,9 +29,8 @@ RUN mkdir -p /etc/newrelic /var/log/newrelic && \
        /etc/newrelic/newrelic.cfg && \
     mv /tmp/newrelic-$NR_VERSION/scripts/newrelic.ini.template \
        /etc/php5/conf.d/newrelic.ini && \
-    rm -rf /tmp/newrelic-php5-$NR_VERSION /tmp/newrelic.tar.gz
-
-RUN mkdir -p /etc/services.d/newrelic && \
+    rm -rf /tmp/newrelic-php5-$NR_VERSION /tmp/newrelic.tar.gz && \
+    mkdir -p /etc/services.d/newrelic && \
     mv /run_newrelic /etc/services.d/newrelic/run
 
 # Volumes

--- a/alpine-php-fpm-drupal7/3.4/Dockerfile
+++ b/alpine-php-fpm-drupal7/3.4/Dockerfile
@@ -19,8 +19,8 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.vcs-ref=$VCS_REF
 
-ENV DRUSH_VERSION=7 \
-    DRUSH_RELEASE=7.4.0
+ENV DRUSH_VERSION=6 \
+    DRUSH_RELEASE=6.7.0
 
 COPY drushrc.php /drushrc.php
 

--- a/alpine-php-fpm-drupal7/3.4/Dockerfile
+++ b/alpine-php-fpm-drupal7/3.4/Dockerfile
@@ -19,39 +19,37 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.vcs-ref=$VCS_REF
 
-ENV COMPOSER_HASH e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae
+ENV DRUSH_VERSION=7 \
+    DRUSH_RELEASE=7.4.0
 
-RUN apk update && \
-    apk add --update-cache \
+COPY drushrc.php /drushrc.php
+
+RUN apk add --update-cache \
       php5-cli \
       mysql-client \
       postgresql-client  && \
-    rm -rf /var/cache/apk/*
-
-# Set unlimited memory for CLI php.
-RUN sed -i 's/^memory_limit = .*/memory_limit = -1/' /etc/php5/php.ini
-
-# Install composer, as suggested by https://getcomposer.org/
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+    rm -rf /var/cache/apk/* && \
+    # Set unlimited memory for CLI php.
+    sed -i 's/^memory_limit = .*/memory_limit = -1/' /etc/php5/php.ini && \
+    # Install composer, as suggested by https://getcomposer.org/
+    # and https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+    COMPOSER_HASH=$(curl -sS https://composer.github.io/installer.sig) && \
+    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
     php -r "if (hash_file('SHA384', 'composer-setup.php') === '$COMPOSER_HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
     php composer-setup.php --install-dir=/usr/bin --filename=composer && \
-    php -r "unlink('composer-setup.php');"
-
-# Install drush and symlink it somewhere useful.
-RUN COMPOSER_HOME=/usr/local/drush \
-    composer global require drush/drush 6.7
-RUN ln -sf /usr/local/drush/vendor/bin/drush /usr/bin/drush
-
-# Install registry_rebuild to the appuser's homedir.
-RUN drush -y @none dl --destination=/home/appuser/.drush/commands registry_rebuild
-
-# Symlink the appuser's drush module to root's.
-RUN mkdir -p /root/.drush
-RUN ln -s /home/appuser/.drush/commands /root/.drush/commands
-
-# Add our default drushrc.php file.
-COPY drushrc.php /drushrc.php
-RUN mkdir -p /etc/drush && \
+    php -r "unlink('composer-setup.php');" && \
+    # Install drush and symlink it somewhere useful.
+    COMPOSER_HOME=/usr/local/drush$DRUSH_VERSION \
+      composer global require drush/drush:$DRUSH_RELEASE && \
+    ln -sf /usr/local/drush$DRUSH_VERSION/vendor/bin/drush /usr/bin/drush && \
+    drush status && \
+    # Install registry_rebuild to the appuser's homedir.
+    drush -y @none dl --destination=/home/appuser/.drush/commands registry_rebuild && \
+    # Symlink the appuser's drush module to root's.
+    mkdir -p /root/.drush && \
+    ln -s /home/appuser/.drush/commands /root/.drush/commands && \
+    # Add our default drushrc.php file.
+    mkdir -p /etc/drush && \
     mv /drushrc.php /etc/drush/drushrc.php
 
 # Volumes


### PR DESCRIPTION
- Regroup ENV and RUN directives to reduce the number of layers.
- Use "dynamic hash" for composer instead of fixed one as per https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
- ~~Change version of drush to 7.x because 6.x is not supported anymore. No breaking changes between 7.x and 6.x.~~

@cafuego ~~As stated above, I changed the drush version to the latest supported version for D6 and D7. But, since this image is for D7, I wonder if we shouldn't use drush 8 instead.~~

**Reverted to drush 6**
