### PR TITLE
close OPS-1028.

### DIFF
--- a/alpine-mysql/Dockerfile
+++ b/alpine-mysql/Dockerfile
@@ -15,8 +15,9 @@ RUN mkdir -p /etc/services.d/mysql && \
     mv /run_mysql /etc/services.d/mysql/run && \
     mkdir -p /etc/fix-attrs.d && \
     cp /fix_data_dir /etc/fix-attrs.d/01-fix-data-dir && \
-    cp /fix_logs_dir /etc/fix-attrs.d/02-fix-logs-dir
+    cp /fix_logs_dir /etc/fix-attrs.d/02-fix-logs-dir && \
+    cp /fix_tmp_dir  /etc/fix-attrs.d/03-fix-tmp-dir
 
 EXPOSE 3306
 
-VOLUME ["/srv/db"]
+VOLUME ["/var/lib/mysql" "/var/log/mysql" "/var/tmp/mysql"]

--- a/alpine-mysql/fix_logs_dir
+++ b/alpine-mysql/fix_logs_dir
@@ -1,3 +1,1 @@
-/var/log/mysql-error-logs true nobody,32768:32768 0644 2700
-/var/log/mysql-general-logs true nobody,32768:32768 0644 2700
-/var/log/mysql-slow-query-logs true nobody,32768:32768 0644 2700
+/var/log/mysql mysql 0644 2700

--- a/alpine-mysql/fix_tmp_dir
+++ b/alpine-mysql/fix_tmp_dir
@@ -1,0 +1,1 @@
+/var/tmp/mysql true mysql 0600 0700


### PR DESCRIPTION
- expose three volumes instead of one (data, logs, temp).
- revert the path of the data volume to a more classic one.
- improve the permission fix script for logs.
