### PR TITLE
Fix - alpine-mysql - ownership file and data dir

### DIFF
--- a/alpine-mysql/Dockerfile
+++ b/alpine-mysql/Dockerfile
@@ -3,7 +3,7 @@ FROM unocha/alpine-base-mysql
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 ENV LANG=en_US.utf8 \
-    MYSQL_DIR=/srv/db \
+    MYSQL_DIR=/var/lib/mysql \
     MYSQL_ROOT_PASS=rootpass \
     MYSQL_DB=test_db \
     MYSQL_USER=test_user \

--- a/alpine-mysql/fix_logs_dir
+++ b/alpine-mysql/fix_logs_dir
@@ -1,1 +1,1 @@
-/var/log/mysql mysql 0644 2700
+/var/log/mysql true mysql 0644 2700


### PR DESCRIPTION
- Add missing parameter inside the file to set up ownership of logs directory
- Change env variable for MySQL data dir to match exposed volumes added in PR #69
