### PR TITLE
New image - unocha/alpine-varnish (varnish 4)

### DIFF
--- a/alpine-varnish/3.4/Dockerfile
+++ b/alpine-varnish/3.4/Dockerfile
@@ -1,0 +1,25 @@
+FROM unocha/alpine-base-s6:3.4
+
+MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
+
+ENV DAEMON_USER=varnish \
+    LISTEN_ADDR=0.0.0.0 \
+    LISTEN_PORT=80 \
+    CONFIG_FILE=/etc/varnish/default.vcl \
+    STORAGE_BACKEND=malloc,128M \
+    # Extra options to pass to the varnish daemon.
+    VARNISHD_OPTS=
+
+COPY run_varnish default.vcl /
+
+RUN apk add --update-cache varnish && \
+    rm -rf /var/cache/apk/* && \
+    mkdir -p /etc/services.d/varnish /etc/varnish && \
+    mv /run_varnish /etc/services.d/varnish/run && \
+    mv /default.vcl /etc/varnish/ && \
+    chown -R varnish:varnish /etc/varnish
+
+EXPOSE 80 6082
+
+# Volumes
+# - Conf: /etc/varnish (default.vcl)

--- a/alpine-varnish/3.4/default.vcl
+++ b/alpine-varnish/3.4/default.vcl
@@ -1,0 +1,40 @@
+#
+# This is an example VCL file for Varnish.
+#
+# It does not do anything by default, delegating control to the
+# builtin VCL. The builtin VCL is called when there is no explicit
+# return statement.
+#
+# See the VCL chapters in the Users Guide at https://www.varnish-cache.org/docs/
+# and http://varnish-cache.org/trac/wiki/VCLExamples for more examples.
+
+# Marker to tell the VCL compiler that this VCL has been adapted to the
+# new 4.0 format.
+vcl 4.0;
+
+# Default backend definition. Set this to point to your content server.
+backend default {
+    .host = "127.0.0.1";
+    .port = "8080";
+}
+
+sub vcl_recv {
+    # Happens before we check if we have this in cache already.
+    #
+    # Typically you clean up the request here, removing cookies you don't need,
+    # rewriting the request, etc.
+}
+
+sub vcl_backend_response {
+    # Happens after we have read the response headers from the backend.
+    #
+    # Here you clean the response headers, removing silly Set-Cookie headers
+    # and other mistakes your backend does.
+}
+
+sub vcl_deliver {
+    # Happens when we have all the pieces we need, and are about to send the
+    # response to the client.
+    #
+    # You can do accounting or modifying the final object here.
+}

--- a/alpine-varnish/3.4/run_varnish
+++ b/alpine-varnish/3.4/run_varnish
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv sh
+
+exec /usr/sbin/varnishd -j unix,user=$DAEMON_USER -F -a $LISTEN_ADDR:$LISTEN_PORT -f $CONFIG_FILE -s $STORAGE_BACKEND $VARNISHD_OPTS


### PR DESCRIPTION
Docker file for a generic varnish 4 alpine image.

Running:
- A `/etc/varnish/default.vcl` file should be mounted.
- In memory storage can be set up via STORAGE_BACKEND (ex: malloc,1G).
- Additional settings can be passed to the daemon via VARNISHD_OPTS.
