### PR TITLE
OPS-682: Upgrade wkhtmltopdf image

### DIFF
--- a/alpine-wkhtmltopdf/Dockerfile
+++ b/alpine-wkhtmltopdf/Dockerfile
@@ -2,12 +2,16 @@ FROM unocha/alpine-nodejs:latest
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
+ENV DISPLAY=:100.0
 ENV PORT=3000
+
+COPY run_node /etc/services.d/node/run
 
 RUN apk add --update-cache \
         xvfb \
         ttf-freefont \
-        fontconfig && \
+        fontconfig \
+        dbus && \
     apk add --update-cache \
             --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
             --allow-untrusted \

--- a/alpine-wkhtmltopdf/Dockerfile
+++ b/alpine-wkhtmltopdf/Dockerfile
@@ -16,9 +16,4 @@ RUN apk add --update-cache \
             --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
             --allow-untrusted \
         wkhtmltopdf && \
-    apk add --update-cache \
-        python \
-        make \
-        g++ && \
-    npm install wkhtmltox && \
     rm -rf /var/cache/apk/*

--- a/alpine-wkhtmltopdf/run_node
+++ b/alpine-wkhtmltopdf/run_node
@@ -1,0 +1,16 @@
+#!/usr/bin/with-contenv sh
+
+echo "==> Starting framebuffer display on $DISPLAY"
+Xvfb $DISPLAY -ac &
+
+cd $NODE_APP_DIR
+
+# if $NODE_APP_DIR is empty, this will just spin up a lame nodejs instance
+$(test "$(ls -A "$NODE_APP_DIR" 2>/dev/null)") || \
+ (ln -s /srv/example/server.js /srv/www/ && ln -s /srv/example/package.json /srv/www/)
+
+echo "==> Installing npm dependencies"
+npm install
+
+echo "==> Starting the server"
+exec npm start


### PR DESCRIPTION
This PR fixes the "QXcbConnection: Could not connect to display" described in OPS-682. This runs Xvfb on container start up to create a virtual framebuffer that wkhtmltopdf uses.

This also adds dbus to fix a missing dependency error, and removes some extra dependencies that are not needed.
