### PR TITLE
mongo: parametrize dbpath; add mongo extra options env var.

### DIFF
--- a/alpine-mongo/Dockerfile
+++ b/alpine-mongo/Dockerfile
@@ -2,13 +2,14 @@ FROM unocha/alpine-base-mongo:latest
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
-ENV LANG=en_US.utf8
+ENV LANG=en_US.utf8 \
+    DB_PATH=/srv/db
 
-COPY run_mongo /
+COPY run_mongo /tmp/
 
 RUN mkdir -p /etc/services.d/mongo && \
-    mv /run_mongo /etc/services.d/mongo/run
+    mv /tmp/run_mongo /etc/services.d/mongo/run
 
 EXPOSE 27017
 
-VOLUME ["/srv/db"]
+VOLUME ["${DB_PATH}"]

--- a/alpine-mongo/run_mongo
+++ b/alpine-mongo/run_mongo
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv sh
 
-chown mongodb:mongodb /srv/db
+chown -R mongodb:mongodb ${DB_PATH}
 
-exec s6-setuidgid mongodb mongod --dbpath /srv/db
+exec s6-setuidgid mongodb mongod --dbpath ${DB_PATH} ${EXTRA_OPTIONS}


### PR DESCRIPTION
extra options are very useful to easy create a replica set member for example.
this change also address the issue about copying files to root folder ( "/" ) during build.
the last change si that from now on the permissions will be changed recursively.

