### PR TITLE
alpine-elasticsearch: fix docker volumes directive

### DIFF
--- a/alpine-elasticsearch/2/Dockerfile
+++ b/alpine-elasticsearch/2/Dockerfile
@@ -38,7 +38,7 @@ RUN \
 
 EXPOSE 9200 9300
 
-VOLUME ["/etc/elasticsearch" "/var/lib/elasticsearch" "/var/log/elasticsearch"]
+VOLUME ["/etc/elasticsearch", "/var/lib/elasticsearch", "/var/log/elasticsearch"]
 
 # Volumes
 # - Conf: /etc/elasticsearch


### PR DESCRIPTION
The volumes directive in the elasticsearch Dockerfile should be a proper json array (was missing commas).