### PR TITLE
added new relic to base-nodejs image.

### DIFF
--- a/alpine-base-nodejs/Dockerfile
+++ b/alpine-base-nodejs/Dockerfile
@@ -20,8 +20,8 @@ RUN apk add --update-cache \
         bower \
         newrelic \
         && \
-    cp -a /usr/lib/node_modules/newrelic/newrelic.js /srv/www/ && \
-    mkdir -p ${SRC_DIR} ${NODE_APP_DIR}
+    mkdir -p ${SRC_DIR} ${NODE_APP_DIR} && \
+    cp -a /usr/lib/node_modules/newrelic/newrelic.js ${NODE_APP_DIR}
 
 VOLUME ["${SRC_DIR}", "${NODE_APP_DIR}"]
 

--- a/alpine-base-nodejs/Dockerfile
+++ b/alpine-base-nodejs/Dockerfile
@@ -3,7 +3,7 @@ FROM unocha/alpine-base-s6:latest
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 ENV NODE_APP_DIR=/srv/www \
-    NODE_PATH=/usr/local/lib/node_modules \
+    NODE_PATH=/usr/lib/node_modules \
     SRC_DIR=/src \
     NEW_RELIC_HOME=/srv/ \
     NEW_RELIC_LOG_LEVEL=info \

--- a/alpine-base-nodejs/Dockerfile
+++ b/alpine-base-nodejs/Dockerfile
@@ -3,7 +3,12 @@ FROM unocha/alpine-base-s6:latest
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 ENV NODE_APP_DIR=/srv/www \
-    SRC_DIR=/src
+    SRC_DIR=/src \
+    NEW_RELIC_HOME=/srv/ \
+    NEW_RELIC_LOG_LEVEL=info \
+    NEW_RELIC_LICENSE_KEY=aaa \
+    NEW_RELIC_APP_NAME=nodeapp \
+    NEW_RELIC_NO_CONFIG_FILE=True
 
 RUN apk add --update-cache \
         git \
@@ -13,7 +18,9 @@ RUN apk add --update-cache \
     npm install -g \
         grunt-cli \
         bower \
+        newrelic \
         && \
+    cp -a /usr/lib/node_modules/newrelic/newrelic.js /srv/www/ && \
     mkdir -p ${SRC_DIR} ${NODE_APP_DIR}
 
 VOLUME ["${SRC_DIR}", "${NODE_APP_DIR}"]

--- a/alpine-base-nodejs/Dockerfile
+++ b/alpine-base-nodejs/Dockerfile
@@ -3,6 +3,7 @@ FROM unocha/alpine-base-s6:latest
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 ENV NODE_APP_DIR=/srv/www \
+    NODE_PATH=/usr/local/lib/node_modules \
     SRC_DIR=/src \
     NEW_RELIC_HOME=/srv/ \
     NEW_RELIC_LOG_LEVEL=info \

--- a/alpine-base-nodejs/Dockerfile
+++ b/alpine-base-nodejs/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --update-cache \
         newrelic \
         && \
     mkdir -p ${SRC_DIR} ${NODE_APP_DIR} && \
-    cp -a /usr/lib/node_modules/newrelic/newrelic.js ${NODE_APP_DIR}
+    cp -a /usr/lib/node_modules/newrelic/newrelic.js /srv
 
 VOLUME ["${SRC_DIR}", "${NODE_APP_DIR}"]
 

--- a/alpine-nodejs/Dockerfile
+++ b/alpine-nodejs/Dockerfile
@@ -2,18 +2,19 @@ FROM unocha/alpine-base-nodejs:latest
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
-ENV NODE_APP_DIR=/srv/www
+ENV NODE_APP_DIR=/srv/www \
+    PORT=3000
 
-COPY run_node package.json server.js /
+COPY run_node package.json server.js /tmp/
 
 WORKDIR "${NODE_APP_DIR}"
 
 RUN mkdir -p /srv/www /srv/example /etc/services.d/node && \
-    mv /run_node /etc/services.d/node/run && \
-    mv /server.js /srv/example/ && \
-    mv /package.json /srv/example/
+    mv /tmp/run_node /etc/services.d/node/run && \
+    mv /tmp/server.js /srv/example/ && \
+    mv /tmp/package.json /srv/example/
 
-EXPOSE 3000
+EXPOSE ${PORT}
 
 # mainly used to serve stuff so it makes sense to use ${NODE_APP_DIR} as WORKDIR
 VOLUME ["${NODE_APP_DIR}"]

--- a/alpine-nodejs/server.js
+++ b/alpine-nodejs/server.js
@@ -1,9 +1,13 @@
+require('newrelic');
+
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
   res.end('Yep. It\'s working.\n');
-  // console.log('Test successful!');
 })
 
-server.listen(3000, '0.0.0.0');
-console.log("NodeJS web server running on 0.0.0.0:3000");
+var port = process.env.PORT || 3000;
+
+server.listen(port, "0.0.0.0", function() {
+  console.log('Example NodeJS web server running on %s', port);
+});


### PR DESCRIPTION
- add new relic package
- add env vars for app name, licence key and log level
- add env var to disable usage of newrelic.js configuration file (all needed it will come from env vars above)

Once specific env vars are being injected into the docker container at creation time, the only thing left to be able to use new relic is that each app needs to add ```require('newrelic');``` as the first line of the app's main module.
