### PR TITLE
Update mupdf version

### DIFF
--- a/alpine-php-fpm-drupal7-reliefweb/Dockerfile
+++ b/alpine-php-fpm-drupal7-reliefweb/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.vcs-ref=$VCS_REF
 
-ENV MUPDF_VERSION=1.9a \
+ENV MUPDF_VERSION=1.10a \
     PHP_HOEDOWN_VERSION=0.6.5
 
 COPY run_fpm /


### PR DESCRIPTION
Version 1.9a is no longer available on http://mupdf.com/downloads/ - mupdf-1.10a-source.tar.gz is. 

The dockerfile gives up with an unrecoverable error as is - I haven't tested fully with 1.10a. Another option is to add `/archive` the path: `http://mupdf.com/downloads/archive/mupdf-$MUPDF_VERSION-source.tar.gz` 