### PR TITLE
Update path for mupdf download.

### DIFF
--- a/alpine-php-fpm-drupal7-reliefweb/Dockerfile
+++ b/alpine-php-fpm-drupal7-reliefweb/Dockerfile
@@ -29,7 +29,7 @@ RUN mv -f /run_fpm /etc/services.d/fpm/run && \
     cd /tmp && \
     # Build and install MuPDF.
     mkdir -p /tmp/mupdf /opt/mupdf/bin &&\
-    curl -o mupdf-$MUPDF_VERSION-source.tar.gz http://mupdf.com/downloads/mupdf-$MUPDF_VERSION-source.tar.gz && \
+    curl -o mupdf-$MUPDF_VERSION-source.tar.gz http://mupdf.com/downloads/archive/mupdf-$MUPDF_VERSION-source.tar.gz && \
     tar -zxf mupdf-$MUPDF_VERSION-source.tar.gz && \
     cd mupdf-$MUPDF_VERSION-source && \
     # Fix CVE-2016-6265 and CVE-2016-6525.


### PR DESCRIPTION
There's a new version of MuPDF so the download path has changed. 

See: https://humanitarian.atlassian.net/browse/OPS-1751
and: http://mupdf.com/downloads/archive/

A previous PR updated the version of MuPDF: https://github.com/UN-OCHA/docker-images/pull/107 