### PR TITLE
fix parent image tag on alpine-nodejs npm3.

### DIFF
--- a/alpine-nodejs/npm3/Dockerfile
+++ b/alpine-nodejs/npm3/Dockerfile
@@ -1,4 +1,4 @@
-FROM unocha/alpine-nodejs:201610
+FROM unocha/alpine-nodejs:4.6.0-r0-201612-PR104
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 


### PR DESCRIPTION
alpine-nodejs with npm3 image intended to have newrelic, unfortunately it was inherited from an older alpine-base-nodejs image.

