### PR TITLE
[TEST] Add a lint tester for the Dockerfiles (and templates).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "node"
+
+before_script:
+  - npm install -g dockerlint
+
+script:
+  - for file in $(find . -name Dockerfile*); do dockerlint -f ${file} || exit 1; done


### PR DESCRIPTION
Soooo... I think the problem here is mostly that the linter is broken, as it errors out on "single quotes" even if there are no quotes in the file.