### PR TITLE
[OPS-3397] alpine-hubot: Add twilio node dependency.

### DIFF
--- a/alpine-hubot/Dockerfile.tmpl
+++ b/alpine-hubot/Dockerfile.tmpl
@@ -22,7 +22,9 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.distribution="Alpine Linux" \
       org.label-schema.distribution-version="3.4" \
       info.humanitarianresponse.hubot=$VERSION \
-      info.humanitarianresponse.hubot.plugins="hubot-auth hubot-brain-inspect hubot-diagnostics hubot-factoids hubot-flowdock hubot-google-images hubot-google-translate hubot-help hubot-karma hubot-maps hubot-pugme hubot-redis-brain hubot-rules hubot-scripts hubot-shipit"
+      info.humanitarianresponse.hubot.plugins="hubot-auth hubot-brain-inspect hubot-diagnostics hubot-factoids hubot-flowdock hubot-google-images hubot-google-translate hubot-help hubot-karma hubot-maps hubot-pugme hubot-redis-brain hubot-rules hubot-scripts hubot-shipit" \
+      info.humanitarianresponse.hubot.depends="twilio"
+
 
 COPY package.json /
 

--- a/alpine-hubot/package.json
+++ b/alpine-hubot/package.json
@@ -20,7 +20,8 @@
     "hubot-redis-brain": "0.0.3",
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.17.2",
-    "hubot-shipit": "^0.2.0"
+    "hubot-shipit": "^0.2.0",
+    "twilio": "^3.5.0"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
HubbBot's new SMS capabilities require the Twilio node module is installed, so this should install it. :)

Note: JavaScript isn't my first language, so extra eyes to make sure I haven't booched it up would be appreciated.