### PR TITLE
[OPS 3406] Create a php7 image for reliefweb

### DIFF
--- a/alpine-php-fpm-drupal7-reliefweb/php7/Dockerfile.tmpl
+++ b/alpine-php-fpm-drupal7-reliefweb/php7/Dockerfile.tmpl
@@ -22,9 +22,10 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.distribution="Alpine Linux" \
       org.label-schema.distribution-version="3.6" \
       info.humanitarianresponse.php=$VERSION \
-      info.humanitarianresponse.php.modules="bcmath bz2 ctype curl dom fpm imagick json mcrypt mysql opcache openssl pdo pdo_mysql pdo_pgsql phar posix sockets xml xmlreader zip zlib memcached redis" \
+      info.humanitarianresponse.php.modules="bcmath bz2 ctype curl dom fpm gmp imagick json mbstring mcrypt mysql opcache openssl pdo pdo_mysql pdo_pgsql phar posix sockets xml xmlreader xmlwriter zip zlib memcached redis" \
       info.humanitarianresponse.php.sapi="fpm" \
-      info.humanitarianresponse.hoedown=$PHP_HOEDOWN_VERSION
+      info.humanitarianresponse.hoedown=$PHP_HOEDOWN_VERSION \
+      info.humanitarianresponse.mupdf="1.11-r1"
 
 COPY run_fpm /
 

--- a/alpine-php-fpm-drupal7-reliefweb/php7/Dockerfile.tmpl
+++ b/alpine-php-fpm-drupal7-reliefweb/php7/Dockerfile.tmpl
@@ -1,0 +1,64 @@
+FROM unocha/alpine-php-fpm-drupal8:%%UPSTREAM%%
+
+MAINTAINER orakili <docker@orakili.net>
+
+ENV PHP_HOEDOWN_VERSION=0.6.4
+
+# A little bit of metadata management.
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.name="php-fpm-drupal7-reliefweb" \
+      org.label-schema.description="This service provides a php-fpm platform for the reliefweb.int Drupal 7 site with MuPDF and Hoedown." \
+      org.label-schema.architecture="x86_64" \
+      org.label-schema.distribution="Alpine Linux" \
+      org.label-schema.distribution-version="3.6" \
+      info.humanitarianresponse.php=$VERSION \
+      info.humanitarianresponse.php.modules="bcmath bz2 ctype curl dom fpm imagick json mcrypt mysql opcache openssl pdo pdo_mysql pdo_pgsql phar posix sockets xml xmlreader zip zlib memcached redis" \
+      info.humanitarianresponse.php.sapi="fpm" \
+      info.humanitarianresponse.hoedown=$PHP_HOEDOWN_VERSION
+
+COPY run_fpm /
+
+RUN mv -f /run_fpm /etc/services.d/fpm/run && \
+    # Upgrade to have the proper musl library
+    # needed for the build dependencies below.
+    apk --update-cache upgrade && \
+    # Install mutools.
+    apk add \
+      mupdf-tools \
+      php7-gmp && \
+    # Install dependencies to build the Hoedown php extension.
+    apk add --virtual .build-dependencies \
+      autoconf \
+      build-base \
+      git \
+      gzip \
+      patch \
+      php7-dev \
+      tar && \
+    cd /tmp && \
+    # Build and install php-ext-hoedown.
+    git clone --recursive --depth=1 --branch=$PHP_HOEDOWN_VERSION https://github.com/reliefweb/php-ext-hoedown.git /tmp/php-ext-hoedown && \
+    cd /tmp/php-ext-hoedown && \
+    phpize && ./configure && make && make install && \
+    cd /tmp && rm -rf /tmp/php* && \
+    echo "extension=/usr/lib/php7/modules/hoedown.so" > /etc/php7/conf.d/hoedown.ini && \
+    # Remove build dependencies.
+    apk del .build-dependencies && \
+    rm -rf /var/cache/apk/*
+
+EXPOSE 9000
+
+# Volumes
+# - Conf: /etc/php7/ (php-fpm.conf, php.ini, conf.d)
+# - Logs: /var/log/php
+# - Data: /srv/www, /var/lib/php/session

--- a/alpine-php-fpm-drupal7-reliefweb/php7/Makefile
+++ b/alpine-php-fpm-drupal7-reliefweb/php7/Makefile
@@ -1,0 +1,9 @@
+include ../../Makefile.conf
+include ../Makefile.conf
+
+UPSTREAM=$$(UPSTREAM))
+VERSION=$$(VERSION))
+
+all: template build tag clean_images
+
+mrproper: clean_images clean

--- a/alpine-php-fpm-drupal7-reliefweb/php7/run_fpm
+++ b/alpine-php-fpm-drupal7-reliefweb/php7/run_fpm
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv sh
+set -e -u
+
+# Change the appuser UID/GID.
+chown -R $APPUSER_UID:$APPUSER_GID /home/appuser
+deluser appuser
+addgroup -g $APPUSER_GID -S appuser
+adduser -u $APPUSER_UID -s /sbin/nologin -g 'Docker App User' -h /home/appuser -D -G appuser appuser
+
+# Launch php fpm process in the foreground.
+exec /usr/sbin/php-fpm7 -c /etc/php7/php.ini -y /etc/php7/php-fpm.conf -F


### PR DESCRIPTION
PHP7 image for ReliefWeb based on the alpine-php-fpm-drupal8 image (based on alpine-base-php-fpm/php7).

It also includes an upgraded version of mupdf: 1.11 and php hoedown extension: 0.6.4.