### PR TITLE
[OPS-3416] Add modern-syslog to hubot

### DIFF
--- a/alpine-hubot/Dockerfile.tmpl
+++ b/alpine-hubot/Dockerfile.tmpl
@@ -23,7 +23,7 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.distribution-version="3.4" \
       info.humanitarianresponse.hubot=$VERSION \
       info.humanitarianresponse.hubot.plugins="hubot-auth hubot-brain-inspect hubot-diagnostics hubot-factoids hubot-flowdock hubot-google-images hubot-google-translate hubot-help hubot-karma hubot-maps hubot-pugme hubot-redis-brain hubot-rules hubot-scripts hubot-shipit" \
-      info.humanitarianresponse.hubot.depends="twilio"
+      info.humanitarianresponse.hubot.depends="twilio modern-syslog"
 
 
 COPY package.json /

--- a/alpine-hubot/package.json
+++ b/alpine-hubot/package.json
@@ -21,6 +21,7 @@
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.0",
+    "modern-syslog": "^1.1.4",
     "twilio": "^3.5.0"
   },
   "engines": {


### PR DESCRIPTION
Hubot/JebbBot is going to start recording SMS receipts to syslog shortly, and needs the appropriate module to do this. We use the `modern-syslog` npm package, since it's delightful.