### PR TITLE
[OPS-3496] remove volume definitions

### DIFF
--- a/alpine-base-nodejs/Dockerfile
+++ b/alpine-base-nodejs/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 
 ENV NODE_APP_DIR=/srv/www \
     NODE_PATH=/usr/lib/node_modules \
+    NPM_CONFIG_SPIN=false \
+    NPM_CONFIG_PROGRESS=false \
     SRC_DIR=/src \
     NEW_RELIC_HOME=/srv/ \
     NEW_RELIC_LOG_LEVEL=info \
@@ -24,10 +26,15 @@ RUN apk add --update-cache \
         webpack \
         yarn && \
     npm cache clean && \
+    rm -rf /tmp && \
+    mkdir -p /tmp && \
+    chmod 1777 /tmp && \
     mkdir -p ${SRC_DIR} ${NODE_APP_DIR} && \
     cp -a /usr/lib/node_modules/newrelic/newrelic.js /srv
 
-VOLUME ["${SRC_DIR}", "${NODE_APP_DIR}"]
+#define the volumes at run time - far better
+#VOLUME ["${SRC_DIR}", "${NODE_APP_DIR}"]
 
 # mainly used to build stuff so it makes sense to use ${SRC_DIR} as WORKDIR
-WORKDIR ${SRC_DIR}
+# but we let the downstream images to decide
+#WORKDIR ${SRC_DIR}

--- a/alpine-nodejs/Dockerfile
+++ b/alpine-nodejs/Dockerfile
@@ -17,4 +17,5 @@ RUN mkdir -p /srv/www /srv/example /etc/services.d/node /root && \
 EXPOSE ${PORT}
 
 # mainly used to serve stuff so it makes sense to use ${NODE_APP_DIR} as WORKDIR
-VOLUME ["${NODE_APP_DIR}"]
+# but it doesnt make sense to make a volume out of it, unless you are doing it at runtime.
+# VOLUME ["${NODE_APP_DIR}"]


### PR DESCRIPTION
- from base-nodejs and nodejs to make sure it doesnt interfere with more complicated setups.
- added the env vars required to make npm install output less verbose
- add cleaning of /tmp file (apparently npm cache clean only removes the cache dir)

unocha/alpine-base-nodejs and then unocha/alpine-nodejs will be rebuilt.
