### PR TITLE
add alpine's nginx

### DIFF
--- a/nginx/Dockerfile.tmpl
+++ b/nginx/Dockerfile.tmpl
@@ -31,7 +31,7 @@ RUN apk update && \
       nginx-mod-http-upload-progress \
       nginx-mod-http-lua && \
     rm -rf /var/cache/apk/* && \
-    mkdir -p /etc/services.d/nginx /run/nginx /srv/www/html /var/lib/nginx /var/log/nginx /var/cache/nginx && \
+    mkdir -p /etc/services.d/nginx /run/nginx /srv/www/html /var/log/nginx /var/cache/nginx && \
     mv /tmp/run_nginx /etc/services.d/nginx/run && \
     mv /tmp/default.conf /etc/nginx/conf.d/default.conf && \
     mv /tmp/index.html /srv/www/html/index.html
@@ -42,3 +42,4 @@ EXPOSE 80
 # - Conf: /etc/nginx/conf.d (default.conf)
 # - Logs: /var/log/nginx
 # - Data: /srv/www/html
+# - Cache: /var/cache/nginx

--- a/nginx/Dockerfile.tmpl
+++ b/nginx/Dockerfile.tmpl
@@ -1,0 +1,44 @@
+FROM unocha/alpine-base-s6:%%UPSTREAM%%
+
+# Parse arguments for the build command.
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+
+# A little bit of metadata management.
+# See http://label-schema.org/
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.name="nginx" \
+      org.label-schema.description="This service provides a base nginx platform." \
+      org.label-schema.architecture="x86_64" \
+      org.label-schema.distribution="Alpine Linux" \
+      org.label-schema.distribution-version="3.6" \
+      info.humanitarianresponse.nginx=$VERSION
+
+COPY default.conf index.html run_nginx /tmp/
+
+# Install nginx.
+RUN apk update && \
+    apk upgrade && \
+    apk add \
+      nginx \
+      nginx-mod-http-upload-progress \
+      nginx-mod-http-lua && \
+    rm -rf /var/cache/apk/* && \
+    mkdir -p /etc/services.d/nginx /run/nginx /srv/www/html /var/lib/nginx /var/log/nginx /var/cache/nginx && \
+    mv /tmp/run_nginx /etc/services.d/nginx/run && \
+    mv /tmp/default.conf /etc/nginx/conf.d/default.conf && \
+    mv /tmp/index.html /srv/www/html/index.html
+
+EXPOSE 80
+
+# Volumes
+# - Conf: /etc/nginx/conf.d (default.conf)
+# - Logs: /var/log/nginx
+# - Data: /srv/www/html

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.conf
+
+IMAGE=nginx
+VERSION=$$(VERSION)
+
+all: build tag
+
+mrproper: clean_images clean

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,0 +1,3 @@
+make \
+  VERSION=1.10.1-r1 EXTRAVERSION=-201707-02 UPSTREAM=3.6 \
+  clean build tag

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,35 @@
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	# Everything is a 404
+	#location / {
+	#	return 404;
+	#}
+
+	# You may need this to prevent return 404 recursion.
+	location = /404.html {
+		internal;
+	}
+}
+
+root /srv/www/html;
+
+# Define a Logstash log format to output things with time, host, and port.
+log_format logstash '$remote_addr - $remote_user [$time_local] "$request" '
+  '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
+  '$request_time $http_host $http_x_forwarded_proto';
+
+access_log /var/log/nginx/access.log logstash;
+
+# types_hash_max_size 1024;
+# types_hash_bucket_size 512;
+
+# server_names_hash_bucket_size 64;
+# server_names_hash_max_size 512;
+
+gzip on;
+gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+gzip_proxied any;
+gzip_types text/css text/javascript text/plain text/xml application/javascript application/json application/x-javascript application/xml application/xml+rss image/svg+xml;
+  

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -32,4 +32,10 @@ gzip on;
 gzip_disable "MSIE [1-6]\.(?!.*SV1)";
 gzip_proxied any;
 gzip_types text/css text/javascript text/plain text/xml application/javascript application/json application/x-javascript application/xml application/xml+rss image/svg+xml;
-  
+
+set_real_ip_from   127.0.0.1;
+set_real_ip_from   10.0.0.0/8;
+set_real_ip_from   172.16.0.0/12;
+set_real_ip_from   192.168.0.0/16;
+
+real_ip_header     X-Forwarded-For;

--- a/nginx/index.html
+++ b/nginx/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+</body>
+</html>

--- a/nginx/run_nginx
+++ b/nginx/run_nginx
@@ -1,0 +1,5 @@
+#!/usr/bin/with-contenv sh
+
+set -e
+
+exec /usr/sbin/nginx -g "daemon off;" -c /etc/nginx/nginx.conf


### PR DESCRIPTION
this is an attempt to clean a bit the docker images namings and structure.
while following @cafuego's make setup, this nginx is just the latest nginx in the main alpine channel.
the good thing is they started some months ago to also include modules as packages, so compiling from source does not make too much sense now.
i still based it on our base-s6 image just in case we have a edge case where we need to perform some startup actions before actually starting the nginx service.
i will use it when no edge cases just bypassing the s6 init (using `ENTRYPOINT` in docker compose files)