### PR TITLE
[OPS-4055] yarn vs npm

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -15,14 +15,17 @@ SED=sed
 UPSTREAM=
 VERSION=
 EXTRAVERSION=
+EXTRAOPTIONS=
 
 # Common build targets.
 build: clean template
 	$(DOCKER) build \
+		--no-cache \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url | sed 's#git@github.com:#https://github.com/#'` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		--build-arg VERSION=$(VERSION) \
+		$(EXTRAOPTIONS) \
 		. | tee buildlog.txt
 
 # Create a Dockerfile from the template.

--- a/nodejs/base/Dockerfile.tmpl
+++ b/nodejs/base/Dockerfile.tmpl
@@ -2,6 +2,7 @@ FROM unocha/alpine-base-s6:%%UPSTREAM%%
 
 # Parse arguments for the build command.
 ARG NODE_VERSION=6.12.0
+ARG NPM_VERSION=3.10.10
 ARG YARN_VERSION=1.3.2
 ARG VERSION
 ARG VCS_URL
@@ -10,7 +11,7 @@ ARG BUILD_DATE
 
 ENV NODE_VERSION=$NODE_VERSION \
     YARN_VERSION=$YARN_VERSION \
-    NPM_VERSION=3.10.10 \
+    NPM_VERSION=$NPM_VERSION \
     NODE_APP_DIR=/srv/www \
     NODE_PATH=/usr/lib/node_modules:/usr/local/lib/node_modules:/usr/local/share/.config/yarn/global/node_modules \
     NPM_CONFIG_SPIN=false \
@@ -45,10 +46,12 @@ RUN  apk add --no-cache \
         curl \
         git \
   && apk add --no-cache --virtual .build-deps \
+        bash \
         binutils-gold \
         build-base \
         gnupg \
         linux-headers \
+        perl \
         python \
   # gpg keys listed at https://github.com/nodejs/node#release-team
   && for key in \
@@ -71,7 +74,7 @@ RUN  apk add --no-cache \
     && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
     && tar -xf "node-v$NODE_VERSION.tar.xz" \
     && cd "node-v$NODE_VERSION" \
-    && ./configure --prefix=/usr \
+    && ./configure --prefix=/usr --without-npm \
     && make -j$(getconf _NPROCESSORS_ONLN) \
     && make install \
     && cd .. \
@@ -96,19 +99,20 @@ RUN  apk add --no-cache \
         grunt-cli \
         newrelic \
   && yarn cache clean \
+  && cd /tmp \
+  && curl https://codeload.github.com/npm/npm/tar.gz/v${NPM_VERSION} -o npm.tgz \
+  && tar xvzf npm.tgz \
+  && cd npm-${NPM_VERSION} \
+  && make install \
   && apk del .build-deps \
   && rm -rf \
         /usr/lib/node_modules/npm/man \
         /usr/lib/node_modules/npm/doc \
         /usr/lib/node_modules/npm/html \
         /usr/lib/node_modules/npm/scripts \
+        /tmp \
   &&  rm -rf /var/cache/apk/* \
   &&  mkdir -p /tmp \
   &&  chmod 1777 /tmp \
   &&  mkdir -p ${SRC_DIR} ${NODE_APP_DIR} \
-  &&  cp -a /usr/local/share/.config/yarn/global/node_modules/newrelic/newrelic.js /srv \
-  #define the volumes at run time - far better \
-  #VOLUME ["${SRC_DIR}", "${NODE_APP_DIR}"] \
-  # mainly used to build stuff so it makes sense to use ${SRC_DIR} as WORKDIR \
-  # but we let the downstream images to decide \
-  #WORKDIR ${SRC_DIR}
+  &&  cp -a /usr/local/share/.config/yarn/global/node_modules/newrelic/newrelic.js /srv


### PR DESCRIPTION
Since npm 3.10.10 is quite old, we wanted to be able to choose what npm version we use.
I have also modified the `Makefile.conf` so that it pass any **`EXTRAOPTIONS`** to the docker build process as arguments (i needed to make sure the build cache is not baing used).
- make the make command able to pass on args to docker build (like `--build-arg` or `--no-cache`)
- add customisable npm version to install