### PR TITLE
OPS-4135 - Prepare a nodejs 8.9.3 image

### DIFF
--- a/alpine-base-nodejs/Dockerfile.tmpl
+++ b/alpine-base-nodejs/Dockerfile.tmpl
@@ -20,8 +20,8 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.description="This service provides a base nodejs platform." \
       org.label-schema.architecture="x86_64" \
       org.label-schema.distribution="Alpine Linux" \
-      org.label-schema.distribution-version="3.6" \
-      info.humanitarianresponse.nodejs="6.11.4-r0"
+      org.label-schema.distribution-version="3.7" \
+      info.humanitarianresponse.nodejs="8.9.3-r0"
 
 ENV NODE_APP_DIR=/srv/www \
     NODE_PATH=/usr/lib/node_modules \
@@ -38,17 +38,17 @@ RUN apk add --update-cache \
         build-base \
         git \
         python && \
-    apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.7/main \
         nodejs \
         nodejs-npm && \
-    mkdir -p /root/.node-gyp/6.11.4 && \
-    USER=root npm install -g \
+    mkdir -p /root/.node-gyp/8.9.3 && \
+    USER=root npm install -g --unsafe-perm \
         grunt-cli \
         bower \
         newrelic \
         webpack \
         yarn && \
-    npm cache clean && \
+    npm cache verify && \
     rm -rf /tmp /root/.node-gyp && \
     apk del build-base && \
     rm -rf /var/cache/apk/* && \

--- a/alpine-base-s6/3.7/Dockerfile
+++ b/alpine-base-s6/3.7/Dockerfile
@@ -1,0 +1,34 @@
+FROM unocha/alpine-base:3.7
+
+MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
+
+ENV S6_VERSION=1.21.0.0
+
+# Parse arguments for the build command.
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+
+# A little bit of metadata management.
+# See http://label-schema.org/
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.name="base-s6" \
+      org.label-schema.description="This service provides a base Alpine Linux container." \
+      org.label-schema.architecture="x86_64" \
+      org.label-schema.distribution="Alpine Linux" \
+      org.label-schema.distribution-version=$VERSION \
+      org.label-schema.s6-version=$S6_VERSION
+
+RUN curl -sL https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz -o /tmp/s6.tgz && \
+    tar xzf /tmp/s6.tgz -C / && \
+    rm -f /tmp/s6.tgz
+
+ENTRYPOINT ["/init"]
+
+CMD []

--- a/alpine-base-s6/3.7/Dockerfile.tmpl
+++ b/alpine-base-s6/3.7/Dockerfile.tmpl
@@ -1,0 +1,34 @@
+FROM unocha/alpine-base:%%UPSTREAM%%
+
+MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
+
+ENV S6_VERSION=1.21.0.0
+
+# Parse arguments for the build command.
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+
+# A little bit of metadata management.
+# See http://label-schema.org/
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.name="base-s6" \
+      org.label-schema.description="This service provides a base Alpine Linux container." \
+      org.label-schema.architecture="x86_64" \
+      org.label-schema.distribution="Alpine Linux" \
+      org.label-schema.distribution-version=$VERSION \
+      org.label-schema.s6-version=$S6_VERSION
+
+RUN curl -sL https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz -o /tmp/s6.tgz && \
+    tar xzf /tmp/s6.tgz -C / && \
+    rm -f /tmp/s6.tgz
+
+ENTRYPOINT ["/init"]
+
+CMD []

--- a/alpine-base-s6/3.7/Makefile
+++ b/alpine-base-s6/3.7/Makefile
@@ -1,0 +1,8 @@
+include ../../Makefile.conf
+include ../Makefile.conf
+
+VERSION=$$(VERSION)
+
+all: build tag
+
+mrproper: clean_images clean

--- a/alpine-base/3.7/Dockerfile
+++ b/alpine-base/3.7/Dockerfile
@@ -1,0 +1,36 @@
+FROM alpine:3.7
+
+MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
+
+# Parse arguments for the build command.
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+
+# A little bit of metadata management.
+# See http://label-schema.org/
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.name="base" \
+      org.label-schema.description="This service provides a base Alpine Linux container." \
+      org.label-schema.architecture="x86_64" \
+      org.label-schema.distribution="Alpine Linux" \
+      org.label-schema.distribution-version=$VERSION
+
+# Default user id and group id.
+# a good idea from orakili <docker@orakili.net>
+ENV APPUSER_GID=4000 \
+    APPUSER_UID=4000
+
+RUN apk update && \
+    apk upgrade && \
+    apk add --update-cache curl \
+        nano && \
+    rm -rf /var/cache/apk/* && \
+    addgroup -g $APPUSER_GID -S appuser && \
+    adduser -u $APPUSER_UID -s /sbin/nologin -g 'Docker App User' -h /home/appuser -D -G appuser appuser

--- a/alpine-base/3.7/Dockerfile.tmpl
+++ b/alpine-base/3.7/Dockerfile.tmpl
@@ -1,0 +1,36 @@
+FROM alpine:3.7
+
+MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
+
+# Parse arguments for the build command.
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+
+# A little bit of metadata management.
+# See http://label-schema.org/
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.name="base" \
+      org.label-schema.description="This service provides a base Alpine Linux container." \
+      org.label-schema.architecture="x86_64" \
+      org.label-schema.distribution="Alpine Linux" \
+      org.label-schema.distribution-version=$VERSION
+
+# Default user id and group id.
+# a good idea from orakili <docker@orakili.net>
+ENV APPUSER_GID=4000 \
+    APPUSER_UID=4000
+
+RUN apk update && \
+    apk upgrade && \
+    apk add --update-cache curl \
+        nano && \
+    rm -rf /var/cache/apk/* && \
+    addgroup -g $APPUSER_GID -S appuser && \
+    adduser -u $APPUSER_UID -s /sbin/nologin -g 'Docker App User' -h /home/appuser -D -G appuser appuser

--- a/alpine-base/3.7/Makefile
+++ b/alpine-base/3.7/Makefile
@@ -1,0 +1,8 @@
+include ../../Makefile.conf
+include ../Makefile.conf
+
+VERSION=$$(VERSION)
+
+all: build tag
+
+mrproper: clean_images clean

--- a/alpine-nodejs/Dockerfile
+++ b/alpine-nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM unocha/alpine-base-nodejs:3.6-201708-01
+FROM unocha/alpine-base-nodejs:3.7
 
 MAINTAINER Serban Teodorescu <teodorescu.serban@gmail.com>
 


### PR DESCRIPTION
Might be too early for this, but it allows me to have a nodejs 8.9.3 image running locally for my testing. Note the use of "--unsafe-perm" in the npm install commands, which is a workaround to this issue: https://github.com/nodejs/node-gyp/issues/454. Another, better fix might need to be found before this is released...