### PR TITLE
[OPS-4233] Upgrade to mupdf 1.12.0 to fix CVE-2017-17866

### DIFF
--- a/alpine-php-fpm-drupal7-reliefweb/php7/Dockerfile.tmpl
+++ b/alpine-php-fpm-drupal7-reliefweb/php7/Dockerfile.tmpl
@@ -25,7 +25,7 @@ LABEL org.label-schema.schema-version="1.0" \
       info.humanitarianresponse.php.modules="bcmath bz2 ctype curl dom fpm gmp imagick json mbstring mcrypt mysql opcache openssl pdo pdo_mysql pdo_pgsql phar posix simplexml sockets xml xmlreader xmlwriter zip zlib memcached redis" \
       info.humanitarianresponse.php.sapi="fpm" \
       info.humanitarianresponse.hoedown=$PHP_HOEDOWN_VERSION \
-      info.humanitarianresponse.mupdf="1.11-r1"
+      info.humanitarianresponse.mupdf="1.12.0-r0"
 
 COPY run_fpm /
 
@@ -34,8 +34,10 @@ RUN mv -f /run_fpm /etc/services.d/fpm/run && \
     # needed for the build dependencies below.
     apk --update-cache upgrade && \
     # Install mutools.
+    apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main --allow-untrusted \
+      mupdf-tools && \
+    # Install extra PHP packages.
     apk add \
-      mupdf-tools \
       php7-gmp \
       php7-simplexml && \
     # Install dependencies to build the Hoedown php extension.

--- a/alpine-php-fpm-drupal7-reliefweb/php7/Dockerfile.tmpl
+++ b/alpine-php-fpm-drupal7-reliefweb/php7/Dockerfile.tmpl
@@ -33,9 +33,6 @@ RUN mv -f /run_fpm /etc/services.d/fpm/run && \
     # Upgrade to have the proper musl library
     # needed for the build dependencies below.
     apk --update-cache upgrade && \
-    # Install mutools.
-    apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main --allow-untrusted \
-      mupdf-tools && \
     # Install extra PHP packages.
     apk add \
       php7-gmp \
@@ -60,6 +57,10 @@ RUN mv -f /run_fpm /etc/services.d/fpm/run && \
     echo "extension=/usr/lib/php7/modules/hoedown.so" > /etc/php7/conf.d/hoedown.ini && \
     # Remove build dependencies.
     apk del .build-dependencies && \
+    # Install mutools.
+    apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main --allow-untrusted \
+      mupdf-tools && \
+    # Clear the package cache.
     rm -rf /var/cache/apk/*
 
 EXPOSE 9000


### PR DESCRIPTION
Fix for CVE-2017-17866: https://humanitarian.atlassian.net/browse/OPS-4233

Mupdf 1.12.0 is currently only available in `edge/main`.

Image built from this dockerfile was tested locally and working well.

Note: as per discussion with Peter, the installation of mupdf was moved to the end of the dockerfile RUN directive to make sure apk doesn't try to install the other packages from edge as well.
