### PR TITLE
finishing touches on last 9.x postgres

### DIFF
--- a/postgis/Dockerfile.tmpl
+++ b/postgis/Dockerfile.tmpl
@@ -2,6 +2,7 @@ FROM alpine:%%UPSTREAM%%
 
 ARG S6_VERSION=v1.21.4.0
 ARG POSTGIS_VERSION=2.4.4
+ARG POSTGRES_VERSION=9.6.8-r0
 
 # Parse arguments for the build command.
 ARG VERSION
@@ -22,19 +23,18 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.architecture="x86_64" \
       org.label-schema.distribution="Alpine Linux" \
       org.label-schema.distribution-version="%%UPSTREAM%%" \
-      info.humanitarianresponse.s6=$S6_VERSION
-      info.humanitarianresponse.postgis=$POSTGIS_VERSION
-      info.humanitarianresponse.postgresql=$VERSION
-      info.humanitarianresponse.postgresql=$VERSION
+      info.humanitarianresponse.s6=$S6_VERSION \
+      info.humanitarianresponse.postgis=$POSTGIS_VERSION \
+      info.humanitarianresponse.postgresql=$POSTGRES_VERSION
 
 ENV LANG=en_US.utf8 \
     PGDATA=/var/lib/pgsql \
     PG_CONFIG_FILE=/etc/pgsql/postgresql.conf \
-    PGSQL_DB=pg_example \
-    PGSQL_USER=pg_example \
-    PGSQL_PASS=pg_example
+    PGSQL_DB=testdb \
+    PGSQL_USER=testuser \
+    PGSQL_PASS=testpass
 
-COPY fix_pgsql_dirs pg_hba.conf postgresql.conf run_postgres /tmp/
+COPY fix_pgsql_dirs pg_hba.conf postgresql.conf recovery run_postgres /tmp/
 
 RUN apk update && \
     apk upgrade && \
@@ -47,11 +47,12 @@ RUN apk update && \
     curl -sL https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz -o /tmp/s6.tgz && \
     tar xzf /tmp/s6.tgz -C / && \
     rm -f /tmp/s6.tgz && \
-    mkdir -p /etc/services.d/postgres /etc/fix-attrs.d /etc/pgsql && \
+    mkdir -p /etc/services.d/postgres /etc/fix-attrs.d /etc/pgsql /run/postgresql && \
     cp /tmp/fix_pgsql_dirs /etc/fix-attrs.d/ && \
     mv /tmp/run_postgres /etc/services.d/postgres/run && \
     mv /tmp/pg_hba.conf /etc/pgsql/ && \
     mv /tmp/postgresql.conf /etc/pgsql/ && \
+    mv /tmp/recovery /etc/pgsql/ && \
     touch /etc/pgsql/pg_ident.conf && \
     echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk add --update-cache \
@@ -83,7 +84,13 @@ RUN apk update && \
     apk del postgresql-dev perl file geos-dev \
             libxml2-dev gdal-dev proj4-dev \
             gcc make libgcc g++ && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* && \
+    echo "removing useless, duplicates postgis sql files" && \
+    find /usr/share/postgresql/extension \
+        -iname "postgis*--2.[0-9].[0-9]--${POSTGIS_VERSION}.sql" \
+        ! -iname "postgis*--2.4.4--${POSTGIS_VERSION}.psql" \
+        -print \
+        -delete
 
 ENTRYPOINT ["/init"]
 

--- a/postgis/fix_pgsql_dirs
+++ b/postgis/fix_pgsql_dirs
@@ -1,3 +1,3 @@
-/tmp false root 1777
-#/run/postgresql true postgres 0600 0700
+/tmp false root 0666 1777
+/run/postgresql true postgres 0600 0700
 /var/lib/pgsql true postgres 0600 0700

--- a/postgis/postgresql.conf
+++ b/postgis/postgresql.conf
@@ -2,7 +2,7 @@ data_directory = '/var/lib/pgsql'
 hba_file = '/etc/pgsql/pg_hba.conf'
 ident_file = '/etc/pgsql/pg_ident.conf'
 
-listen_addresses = '*'
+listen_addresses = '0.0.0.0'
 
 # (change requires restart)
 port = 5432

--- a/postgis/recovery
+++ b/postgis/recovery
@@ -1,0 +1,3 @@
+standby_mode = 'on'
+primary_conninfo = 'user=replicator password=replicatorpassword host=mymaster port=5432 sslmode=prefer sslcompression=1'
+trigger_file = '/tmp/postgresql.trigger'

--- a/postgis/run_postgres
+++ b/postgis/run_postgres
@@ -1,42 +1,33 @@
 #!/usr/bin/with-contenv sh
 
-mkdir -p ${PGDATA}
+mkdir -p $PGDATA
 
-# taken care of in initialization
-#chown -R postgres:postgres ${PGDATA}
+# if data folder is empty
+if [ "$(find $PGDATA ! -path $PGDATA | wc -l)" == "0" ]; then
 
-# if data folder is empty, initialize db
-test "$(ls -A "$PGDATA" 2>/dev/null)" || s6-setuidgid postgres /usr/bin/initdb -D $PGDATA
+    # initialize db
+    s6-setuidgid postgres pg_ctl initdb -w -D $PGDATA
 
-# add md5 auth option for all internal clients
-[ $(grep -cE "host(\s)+all(\s)+all(\s)+0.0.0.0/0(\s)+md5" $PGDATA/pg_hba.conf) -eq 1 ] || \
-  echo "host all all 0.0.0.0/0 md5" >> $PGDATA/pg_hba.conf
+    # add a user, pass and a postgis-enabled database owned by that user
+    # get rid of IPv6 error by forcing it to listen only on localhost
+    s6-setuidgid postgres pg_ctl start -w -o "-h '127.0.0.1'"
 
-# add a user, pass and a database owned by that user
-TMP_FILE=/tmp/pgsql.initialize.txt
-# also add postgis extensions to that db
-TMP_GIS_FILE=/tmp/pggis.initialize.txt
-if [ ! -f $TMP_FILE ]; then
-    # create user and db
-    PGSQL_USER=${PGSQL_USER:-"dbuser"}
-    PGSQL_PASS=${PGSQL_PASS:-"dbpass"}
-    PGSQL_DB=${PGSQL_DB:-"dbname"}
-    cat > $TMP_FILE << EOSQL
+    # add a user, pass and a postgis-enabled database owned by that user
+    s6-setuidgid postgres psql -a << EOF
 CREATE USER $PGSQL_USER WITH SUPERUSER;
 ALTER USER $PGSQL_USER WITH PASSWORD '$PGSQL_PASS';
 CREATE DATABASE $PGSQL_DB OWNER $PGSQL_USER;
-EOSQL
-    cat > $TMP_GIS_FILE << EOSQL
+EOF
+
+    # create postgis extensions on that database
+    s6-setuidgid postgres psql -a -U $PGSQL_USER $PGSQL_DB << EOF
 CREATE EXTENSION postgis;
 CREATE EXTENSION postgis_topology;
-EOSQL
-    s6-setuidgid postgres pg_ctl -w start
-    s6-setuidgid postgres psql -a -f $TMP_FILE
-    s6-setuidgid postgres psql -a -U $PGSQL_USER $PGSQL_DB -f $TMP_GIS_FILE
-    s6-setuidgid postgres pg_ctl stop
+EOF
+
+    sleep 2
+    s6-setuidgid postgres pg_ctl -w stop
+
 fi
 
-args="-D ${PGDATA}"
-[ -z ${PG_CONFIG_FILE} ] || args="--config-file=${PG_CONFIG_FILE}"
-
-exec s6-setuidgid postgres /usr/bin/postgres -h 0.0.0.0 $args
+exec s6-setuidgid postgres /usr/bin/postgres -h 0.0.0.0 -D ${PGDATA} --config-file=${PG_CONFIG_FILE}

--- a/postgis/run_postgres
+++ b/postgis/run_postgres
@@ -3,7 +3,7 @@
 mkdir -p $PGDATA
 
 # if data folder is empty
-if [ "$(find $PGDATA ! -path $PGDATA | wc -l)" == "0" ]; then
+if [ "$(find $PGDATA -maxdepth 1 ! -path $PGDATA | wc -l)" == "0" ]; then
 
     # initialize db
     s6-setuidgid postgres pg_ctl initdb -w -D $PGDATA


### PR DESCRIPTION
- `pg_example` is reserved... :)
- replaced `'*'` with `'0.0.0.0'` to get rid of a complaint message saying it cannot bind to the IPv6 address.
- batteries included this time. we will probably want to drop a lot of env variables and configs mapped from the stacks to the container.