### PR TITLE
[OPS-5094] Add -x command line param to keepalived.

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -24,6 +24,7 @@ build: clean template
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url | sed 's#git@github.com:#https://github.com/#'` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		--build-arg UPSTREAM=$(UPSTREAM) \
 		--build-arg VERSION=$(VERSION) \
 		$(EXTRAOPTIONS) \
 		. | tee buildlog.txt

--- a/alpine-keepalived/Dockerfile.tmpl
+++ b/alpine-keepalived/Dockerfile.tmpl
@@ -2,6 +2,7 @@ FROM alpine:%%UPSTREAM%%
 
 # Parse arguments for the build command.
 ARG VERSION
+ARG UPSTREAM
 ARG VCS_URL
 ARG VCS_REF
 ARG BUILD_DATE
@@ -18,7 +19,7 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.description="This service provides keepalived." \
       org.label-schema.architecture="x86_64" \
       org.label-schema.distribution="Alpine Linux" \
-      org.label-schema.distribution-version="3.6" \
+      org.label-schema.distribution-version=${UPSTREAM} \
       info.humanitarianresponse.ipvsadm="1.29-r0" \
       info.humanitarianresponse.keepalived=$VERSION
 
@@ -34,16 +35,14 @@ RUN apk update && \
         postgresql-client \
         python3 \
         redis \
+        docker \
         && \
     apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-      ipvsadm \
-        && \
-    apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
-      docker \
+        ipvsadm \
         && \
     pip3 install --no-cache-dir docker-compose && \
     rm -rf /var/cache/apk/*
 
-ENTRYPOINT ["/usr/sbin/keepalived", "-D", "-n"]
+ENTRYPOINT ["/usr/sbin/keepalived", "-D", "-n", "-x"]
 
 # Wants /etc/keepalived mounted as well as /dev/log and /var/run/docker.sock

--- a/alpine-keepalived/Dockerfile.tmpl
+++ b/alpine-keepalived/Dockerfile.tmpl
@@ -19,7 +19,7 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.description="This service provides keepalived." \
       org.label-schema.architecture="x86_64" \
       org.label-schema.distribution="Alpine Linux" \
-      org.label-schema.distribution-version=${UPSTREAM} \
+      org.label-schema.distribution-version=$UPSTREAM \
       info.humanitarianresponse.ipvsadm="1.29-r0" \
       info.humanitarianresponse.keepalived=$VERSION
 


### PR DESCRIPTION
* Allows us to query keepalived for status via snmp
* Bump upstream version to Alpine 3.8
* Docker is now in main