### PR TITLE
[OPS-5841] Make the advagg cache rules work on any site.

### DIFF
--- a/alpine-php/php7/k8s/etc/nginx/apps/drupal/drupal.conf
+++ b/alpine-php/php7/k8s/etc/nginx/apps/drupal/drupal.conf
@@ -81,6 +81,11 @@ location / {
         internal;
     }
 
+    ## Trying to access private files directly returns a 404.
+    location ^~ /sites/(.*)/private/ {
+        internal;
+    }
+
     ## Support for the file_force module
     ## http://drupal.org/project/file_force.
     location ^~ /(ar|en|fr|ru|es)/system/files_force/ {
@@ -127,30 +132,14 @@ location / {
 
     ## Advanced Aggregation module CSS
     ## support. http://drupal.org/project/advagg.
-    location ^~ /sites/default/files/advagg_css/ {
-        expires max;
-        add_header ETag '';
-        add_header Last-Modified 'Wed, 20 Jan 1988 04:20:42 GMT';
-        add_header Accept-Ranges '';
-
-        location ~* /sites/default/files/advagg_css/css[_[:alnum:]]+\.css$ {
-            access_log off;
-            try_files $uri @drupal;
-        }
-    }
-
-    ## Advanced Aggregation module JS
-    ## support. http://drupal.org/project/advagg.
-    location ^~ /sites/default/files/advagg_js/ {
-        expires max;
-        add_header ETag '';
-        add_header Last-Modified 'Wed, 20 Jan 1988 04:20:42 GMT';
-        add_header Accept-Ranges '';
-
-        location ~* /sites/default/files/advagg_js/js[_[:alnum:]]+\.js$ {
-            access_log off;
-            try_files $uri @drupal;
-        }
+    location ~* /files/advagg_(?:css|js)/ {
+        gzip_static on;
+        access_log  off;
+        expires     max;
+        add_header  ETag "";
+        Cache-Control "max-age=31449600, no-transform, public";
+        add_header  Accept-Ranges '';
+        try_files $uri $uri/ @drupal;
     }
 
     ## All static files will be served directly.
@@ -177,26 +166,22 @@ location / {
     }
 
     ## MP3 and Ogg/Vorbis files are served using AIO when supported. Your OS must support it.
-    location ^~ /sites/default/files/audio/mp3 {
-        location ~* ^/sites/default/files/audio/mp3/.*\.mp3$ {
-            directio 4k; # for XFS
-            ## If you're using ext3 or similar uncomment the line below and comment the above.
-            #directio 512; # for ext3 or similar (block alignments)
-            tcp_nopush off;
-            aio on;
-            output_buffers 1 2M;
-        }
+    location ~* /files/audio/mp3/.*\.mp3$ {
+        directio 4k; # for XFS
+        ## If you're using ext3 or similar uncomment the line below and comment the above.
+        #directio 512; # for ext3 or similar (block alignments)
+        tcp_nopush off;
+        aio on;
+        output_buffers 1 2M;
     }
 
-    location ^~ /sites/default/files/audio/ogg {
-        location ~* ^/sites/default/files/audio/ogg/.*\.ogg$ {
-            directio 4k; # for XFS
-            ## If you're using ext3 or similar uncomment the line below and comment the above.
-            #directio 512; # for ext3 or similar (block alignments)
-            tcp_nopush off;
-            aio on;
-            output_buffers 1 2M;
-        }
+    location ~* /files/audio/ogg/.*\.ogg$ {
+        directio 4k; # for XFS
+        ## If you're using ext3 or similar uncomment the line below and comment the above.
+        #directio 512; # for ext3 or similar (block alignments)
+        tcp_nopush off;
+        aio on;
+        output_buffers 1 2M;
     }
 
     ## Pseudo streaming of FLV files:


### PR DESCRIPTION
By not matching on sites/default/files the rule will also work for sites
that use a named directory for config (e.g: reliefweb, hr.info).

Whilst in there, also tidy up other location smatching rules for
directories under sites/*/files and sites/* private so they will work
regardless of the site directory name.