### PR TITLE
[OPS-5854] Allow custom nginx config, load it from /etc/nginx/custom.

### DIFF
--- a/alpine-php/php7/k8s/etc/nginx/sites-enabled/default.conf
+++ b/alpine-php/php7/k8s/etc/nginx/sites-enabled/default.conf
@@ -55,6 +55,9 @@ server {
     ## Uncomment if you're proxying to Apache for handling PHP.
     #proxy_http_version 1.1; # keep alive to the Apache upstream
 
+    ## Optionally include custom config files from outside the container.
+    include /etc/nginx/custom/*.conf;
+
     ################################################################
     ### Generic configuration: for most Drupal 7 sites.
     ################################################################


### PR DESCRIPTION
If /etc/nginx/custom is absent or empty, this directive does *not* cause nginx errors or warnings.