### PR TITLE
[OPS-5945] add nginx purge cache module; drop s6init as entrypoint

### DIFF
--- a/nginx/Dockerfile.tmpl
+++ b/nginx/Dockerfile.tmpl
@@ -1,4 +1,5 @@
-FROM unocha/alpine-base-s6:%%UPSTREAM%%
+FROM unocha/alpine-base:%%UPSTREAM%%
+# FROM unocha/alpine-base-s6:%%UPSTREAM%%
 
 # Parse arguments for the build command.
 ARG VERSION
@@ -21,7 +22,8 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.distribution-version="%%UPSTREAM%%" \
       info.humanitarianresponse.nginx=$VERSION
 
-COPY default.conf index.html run_nginx /tmp/
+#COPY default.conf index.html run_nginx /tmp/
+COPY default.conf index.html /tmp/
 
 # Install nginx.
 RUN apk update && \
@@ -32,12 +34,16 @@ RUN apk update && \
       nginx-mod-http-lua \
       nginx-mod-http-cache-purge && \
     rm -rf /var/cache/apk/* && \
-    mkdir -p /etc/services.d/nginx /run/nginx /srv/www/html /var/log/nginx /var/cache/nginx && \
-    mv /tmp/run_nginx /etc/services.d/nginx/run && \
+    mkdir -p  /run/nginx /srv/www/html /var/log/nginx /var/cache/nginx && \
     mv /tmp/default.conf /etc/nginx/conf.d/default.conf && \
     mv /tmp/index.html /srv/www/html/index.html
 
+#    mv /tmp/run_nginx /etc/services.d/nginx/run && \
+#    mkdir -p /etc/services.d/nginx /run/nginx /srv/www/html /var/log/nginx /var/cache/nginx && \
+
 EXPOSE 80
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]
 
 # Volumes
 # - Conf: /etc/nginx/conf.d (default.conf)

--- a/nginx/Dockerfile.tmpl
+++ b/nginx/Dockerfile.tmpl
@@ -29,7 +29,8 @@ RUN apk update && \
     apk add \
       nginx \
       nginx-mod-http-upload-progress \
-      nginx-mod-http-lua && \
+      nginx-mod-http-lua \
+      nginx-mod-http-cache-purge && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /etc/services.d/nginx /run/nginx /srv/www/html /var/log/nginx /var/cache/nginx && \
     mv /tmp/run_nginx /etc/services.d/nginx/run && \

--- a/nginx/Dockerfile.tmpl
+++ b/nginx/Dockerfile.tmpl
@@ -1,5 +1,4 @@
 FROM unocha/alpine-base:%%UPSTREAM%%
-# FROM unocha/alpine-base-s6:%%UPSTREAM%%
 
 # Parse arguments for the build command.
 ARG VERSION
@@ -22,7 +21,6 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.distribution-version="%%UPSTREAM%%" \
       info.humanitarianresponse.nginx=$VERSION
 
-#COPY default.conf index.html run_nginx /tmp/
 COPY default.conf index.html /tmp/
 
 # Install nginx.
@@ -37,9 +35,6 @@ RUN apk update && \
     mkdir -p  /run/nginx /srv/www/html /var/log/nginx /var/cache/nginx && \
     mv /tmp/default.conf /etc/nginx/conf.d/default.conf && \
     mv /tmp/index.html /srv/www/html/index.html
-
-#    mv /tmp/run_nginx /etc/services.d/nginx/run && \
-#    mkdir -p /etc/services.d/nginx /run/nginx /srv/www/html /var/log/nginx /var/cache/nginx && \
 
 EXPOSE 80
 


### PR DESCRIPTION
A new nginx image has been built and pushed. The new tags are:
- 1.14
- 1.14.2
- 1.14.2-r1
The new image is being used experimentally on the DSR dev stack