### PR TITLE
[OPS-6033] Without bash, we cannot transparently compress the drush d…

### DIFF
--- a/alpine-php/php7/Dockerfile.tmpl
+++ b/alpine-php/php7/Dockerfile.tmpl
@@ -34,6 +34,7 @@ COPY etc/my.cnf.d/client.cnf /client.cnf
 COPY drushrc.php /drushrc.php
 
 RUN apk add --update-cache \
+        bash \
         git \
         php7 \
         mysql-client && \


### PR DESCRIPTION
…atabase dump.

Adding it here means that the call to `apk add -U bash` in all the
database-backup Jenkins jobs can go away.