### PR TITLE
[OPS-5937] Bump PHP hoedown in reliefweb image

### DIFF
--- a/alpine-php/php7/reliefweb/Dockerfile.tmpl
+++ b/alpine-php/php7/reliefweb/Dockerfile.tmpl
@@ -2,7 +2,7 @@ FROM unocha/php7:%%UPSTREAM%%
 
 MAINTAINER orakili <docker@orakili.net>
 
-ENV PHP_HOEDOWN_VERSION=0.6.7
+ENV PHP_HOEDOWN_VERSION=0.6.8
 
 # A little bit of metadata management.
 ARG BUILD_DATE


### PR DESCRIPTION
Bump to PHP hoedown 0.6.8 which has the tiny fix for the failing test mentioned in https://humanitarian.atlassian.net/browse/OPS-5937