### PR TITLE
[OPS-6138] Always default to the logstash format.

### DIFF
--- a/alpine-base-nginx/nginx.conf
+++ b/alpine-base-nginx/nginx.conf
@@ -19,12 +19,13 @@ http {
     '$status $body_bytes_sent "$http_referer" '
     '"$http_user_agent" "$http_x_forwarded_for"';
 
-  # Define a Logstash log format to output things with time, host, and port.
-  log_format logstash '$remote_addr - $remote_user [$time_local] "$request" '
+  # Define an internal Logstash log format to output things with time, host, and port.
+  # and that does not name clash with a possible identical format defined in a vhost.
+  log_format builtin_logstash '$remote_addr - $remote_user [$time_local] "$request" '
   '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
   '$request_time $http_host $http_x_forwarded_proto';
 
-  access_log /var/log/nginx/access.log logstash;
+  access_log /var/log/nginx/access.log builtin_logstash;
 
   sendfile on;
 

--- a/alpine-base-nginx/nginx.conf
+++ b/alpine-base-nginx/nginx.conf
@@ -19,7 +19,12 @@ http {
     '$status $body_bytes_sent "$http_referer" '
     '"$http_user_agent" "$http_x_forwarded_for"';
 
-  access_log /var/log/nginx/access.log main;
+  # Define a Logstash log format to output things with time, host, and port.
+  log_format logstash '$remote_addr - $remote_user [$time_local] "$request" '
+  '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
+  '$request_time $http_host $http_x_forwarded_proto';
+
+  access_log /var/log/nginx/access.log logstash;
 
   sendfile on;
 


### PR DESCRIPTION
This *can* mean we get two logs for each access, if the vhost logs to
the same file, but at least they will both parse correctly and not
inflate the report of logs hat failed to parse correctly.

In principle, logstash should drop the duplicate identical log message
anyway, as it would generate an identical hash.