### PR TITLE
[OPS-6139] Add pngquant to ReliefWeb php image

### DIFF
--- a/alpine-php/php7/reliefweb/Dockerfile.tmpl
+++ b/alpine-php/php7/reliefweb/Dockerfile.tmpl
@@ -33,11 +33,12 @@ RUN mv -f /run_fpm /etc/services.d/fpm/run && \
     # Upgrade to have the proper musl library
     # needed for the build dependencies below.
     apk --update-cache upgrade && \
-    # Install mutools.
+    # Install mutools, pngquant and PHP extensions.
     apk add \
       mupdf-tools \
       php7-gmp \
-      php7-simplexml && \
+      php7-simplexml \
+      pngquant && \
     # Install dependencies to build the Hoedown php extension.
     apk add --virtual .build-dependencies \
       autoconf \


### PR DESCRIPTION
JIRA: https://humanitarian.atlassian.net/browse/OPS-6139

This adds pngquant (used to optinize PNG images) to the ReliefWeb php image.