### PR TITLE
[HOTFIX] Bump the fastcgi buffer size, so Drupal cache tag headers do…

### DIFF
--- a/alpine-php/php7/k8s/etc/nginx/fastcgi.conf
+++ b/alpine-php/php7/k8s/etc/nginx/fastcgi.conf
@@ -1,7 +1,8 @@
 #-*- mode: nginx; mode: flyspell-prog; ispell-local-dictionary: "american" -*-
 ### Generic fastcgi configuration.
 include fastcgi_params;
-fastcgi_buffers 256 4k;
+fastcgi_buffers 256 16k;
+fastcgi_buffer_size 32k;
 fastcgi_intercept_errors on;
 ## allow 4 hrs - pass timeout responsibility to upstream.
 fastcgi_read_timeout 14400;


### PR DESCRIPTION
… not blow up.

On dev instances, the cacheability tags can get added in a HTTP header.
This header cna get big. If too big, nginx can't handle it and throws a
502, which is not helpful for cache debugging. Instrad, bump the buffer
so the site just works.

These values tested && working on IASC dev.