### PR TITLE
[OPS-6164] Drupal container tweaks

### DIFF
--- a/alpine-base-php/php7-newrelic/Dockerfile.tmpl
+++ b/alpine-base-php/php7-newrelic/Dockerfile.tmpl
@@ -24,10 +24,10 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.distribution="Alpine Linux" \
       org.label-schema.distribution-version="3.10.2" \
       info.humanitarianresponse.php=$VERSION \
-      info.humanitarianresponse.php.modules="bcmath bz2 calendar ctype curl dom exif fileinfo fpm gd geos gettext iconv imagick json mcrypt memcached opcache openssl pdo pdo_mysql phar posix redis shmop sysvmsg sysvsem sysvshm simplexml sockets wddx xml xmlreader xmlwriter xsl zip zlib" \
+      info.humanitarianresponse.php.modules="bcmath bz2 calendar ctype curl dom exif fileinfo fpm gd geos gettext iconv imagick json mcrypt memcached newrelic opcache openssl pdo pdo_mysql phar posix redis shmop sysvmsg sysvsem sysvshm simplexml sockets wddx xml xmlreader xmlwriter xsl zip zlib" \
       info.humanitarianresponse.php.sapi="fpm"
 
-ENV NR_VERSION php5-9.6.0.255-linux-musl
+ENV NR_VERSION 9.6.0.255
 
 ENV PHP_NEWRELIC_LICENSE="" \
     PHP_NEWRELIC_APPNAME=""
@@ -35,7 +35,7 @@ ENV PHP_NEWRELIC_LICENSE="" \
 COPY run_newrelic etc/php7/conf.d/10_newrelic.ini /
 
 RUN curl -s -o /tmp/newrelic.tar.gz \
-      https://download.newrelic.com/php_agent/release/newrelic-$NR_VERSION.tar.gz && \
+      https://download.newrelic.com/php_agent/archive/$NR_VERSION/newrelic-php5-${NR_VERSION}-linux-musl.tar.gz && \
     mkdir -p /etc/newrelic /var/log/newrelic && \
     tar xvf /tmp/newrelic.tar.gz -C /tmp && \
     mv /tmp/newrelic-$NR_VERSION/daemon/newrelic-daemon.x64 \

--- a/alpine-base-php/php7-newrelic/Dockerfile.tmpl
+++ b/alpine-base-php/php7-newrelic/Dockerfile.tmpl
@@ -38,11 +38,11 @@ RUN curl -s -o /tmp/newrelic.tar.gz \
       https://download.newrelic.com/php_agent/archive/$NR_VERSION/newrelic-php5-${NR_VERSION}-linux-musl.tar.gz && \
     mkdir -p /etc/newrelic /var/log/newrelic && \
     tar xvf /tmp/newrelic.tar.gz -C /tmp && \
-    mv /tmp/newrelic-$NR_VERSION/daemon/newrelic-daemon.x64 \
+    mv /tmp/newrelic-php5-${NR_VERSION}-linux-musl/daemon/newrelic-daemon.x64 \
        /usr/bin/newrelic-daemon && \
-    mv /tmp/newrelic-$NR_VERSION/agent/x64/newrelic-$(php --info | awk '/^PHP API/ {print $NF}').so \
+    mv /tmp/newrelic-php5-${NR_VERSION}-linux-musl/agent/x64/newrelic-$(php --info | awk '/^PHP API/ {print $NF}').so \
        /usr/lib/php7/modules/newrelic.so && \
-    mv /tmp/newrelic-$NR_VERSION/scripts/newrelic.cfg.template \
+    mv /tmp/newrelic-php5-${NR_VERSION}-linux-musl/scripts/newrelic.cfg.template \
        /etc/newrelic/newrelic.cfg && \
     rm -rf /tmp/newrelic-php5* /tmp/newrelic.tar.gz && \
     rm -f /etc/php7/conf.d/newrelic.ini && \

--- a/alpine-base-php/php7/Dockerfile.tmpl
+++ b/alpine-base-php/php7/Dockerfile.tmpl
@@ -95,7 +95,8 @@ RUN \
       php7-xmlwriter \
       php7-xsl \
       php7-zip \
-      php7-zlib && \
+      php7-zlib \
+      pngquant && \
     # Install build dependencies in order to build the memcache and redis extension
     apk add --virtual .build-dependencies \
       autoconf \

--- a/alpine-php/php7/k8s/etc/drush/drushrc.php
+++ b/alpine-php/php7/k8s/etc/drush/drushrc.php
@@ -1,7 +1,7 @@
 <?php
 // Specify a Drupal url *only* if the site has a single canonical name.
-if (strpos(getenv("NGINX_SERVERNAME"), ' ') === FALSE) {
-  $options['l'] = getenv("NGINX_SERVERNAME");
+if (strpos(getenv("NGINX_SERVERNAME"), ',') === FALSE) {
+  $options['l'] = trim(getenv("NGINX_SERVERNAME"));
 }
 
 // Specify a default drupal root.

--- a/alpine-php/php7/k8s/etc/nginx/lua/nginx_servername_main.lua
+++ b/alpine-php/php7/k8s/etc/nginx/lua/nginx_servername_main.lua
@@ -1,6 +1,6 @@
 ngx.ctx.host_name_list = {}
 for name in os.getenv("NGINX_SERVERNAME"):gmatch("[^,]+") do
-  name = name:gsub("%s+", ""):lower()
+  name = name:gsub("\"", ""):gsub("%s+", ""):lower()
   table.insert(ngx.ctx.host_name_list, name)
 end
 return ngx.ctx.host_name_list[1]

--- a/alpine-php/php7/k8s/etc/nginx/lua/nginx_servername_main.lua
+++ b/alpine-php/php7/k8s/etc/nginx/lua/nginx_servername_main.lua
@@ -1,6 +1,6 @@
 ngx.ctx.host_name_list = {}
-for name in os.getenv("NGINX_SERVERNAME"):gmatch("[%S]+") do
-  name = name:lower()
+for name in os.getenv("NGINX_SERVERNAME"):gmatch("[^,]+") do
+  name = name:gsub("%s+", ""):lower()
   table.insert(ngx.ctx.host_name_list, name)
 end
 return ngx.ctx.host_name_list[1]


### PR DESCRIPTION
The LE proxy container uses hostnames separated by commas. We should do the same. This affects GMS and HPC Viewer.