### PR TITLE
[OPS-5482][OPS-6226] Make k8s image useful for interactive sites

### DIFF
--- a/alpine-base-nginx/nginx.conf
+++ b/alpine-base-nginx/nginx.conf
@@ -19,12 +19,13 @@ http {
     '$status $body_bytes_sent "$http_referer" '
     '"$http_user_agent" "$http_x_forwarded_for"';
 
-  # Define a Logstash log format to output things with time, host, and port.
-  log_format logstash '$remote_addr - $remote_user [$time_local] "$request" '
+  # Define an internal Logstash log format to output things with time, host, and port.
+  # and that does not name clash with a possible identical format defined in a vhost.
+  log_format builtin_logstash '$remote_addr - $remote_user [$time_local] "$request" '
   '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
   '$request_time $http_host $http_x_forwarded_proto';
 
-  access_log /var/log/nginx/access.log logstash;
+  access_log /var/log/nginx/access.log builtin_logstash;
 
   sendfile on;
 

--- a/alpine-base-nginx/nginx.conf
+++ b/alpine-base-nginx/nginx.conf
@@ -19,7 +19,12 @@ http {
     '$status $body_bytes_sent "$http_referer" '
     '"$http_user_agent" "$http_x_forwarded_for"';
 
-  access_log /var/log/nginx/access.log main;
+  # Define a Logstash log format to output things with time, host, and port.
+  log_format logstash '$remote_addr - $remote_user [$time_local] "$request" '
+  '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
+  '$request_time $http_host $http_x_forwarded_proto';
+
+  access_log /var/log/nginx/access.log logstash;
 
   sendfile on;
 

--- a/alpine-base-php/php7-newrelic/Dockerfile.tmpl
+++ b/alpine-base-php/php7-newrelic/Dockerfile.tmpl
@@ -27,7 +27,7 @@ LABEL org.label-schema.schema-version="1.0" \
       info.humanitarianresponse.php.modules="bcmath bz2 calendar ctype curl dom exif fileinfo fpm gd geos gettext iconv imagick json mcrypt memcached newrelic opcache openssl pdo pdo_mysql phar posix redis shmop sysvmsg sysvsem sysvshm simplexml sockets wddx xml xmlreader xmlwriter xsl zip zlib" \
       info.humanitarianresponse.php.sapi="fpm"
 
-ENV NR_VERSION 9.6.1.256
+ENV NR_VERSION 9.7.0.258
 
 ENV PHP_NEWRELIC_LICENSE="" \
     PHP_NEWRELIC_APPNAME=""

--- a/alpine-php/php7/k8s/etc/nginx/sites-enabled/default.conf
+++ b/alpine-php/php7/k8s/etc/nginx/sites-enabled/default.conf
@@ -58,7 +58,7 @@ server {
 
     ## Filesystem root of the site and index.
     root /srv/www/html;
-    index index.php;
+    index index.html index.php;
 
     ## If you're using a Nginx version greater or equal to 1.1.4 then
     ## you can use keep alive connections to the upstream be it

--- a/alpine-php/php7/reliefweb/Dockerfile.tmpl
+++ b/alpine-php/php7/reliefweb/Dockerfile.tmpl
@@ -2,7 +2,7 @@ FROM unocha/php7:%%UPSTREAM%%
 
 MAINTAINER orakili <docker@orakili.net>
 
-ENV PHP_HOEDOWN_VERSION=0.6.8
+ENV PHP_HOEDOWN_VERSION=0.6.7
 
 # A little bit of metadata management.
 ARG BUILD_DATE


### PR DESCRIPTION
Really, all it needs is to also honour index.html as directoryindex. I am defaulting to that over index.php if both are present.

As there are new PHP 7.2 and NewRelic releases, I've bumped both before baking a new image.

Honestly, I'm not sure why the the OPS-6138 change is in here, but it doesn't matter, that should get merged as-is anyway and is not in fact used in the PHP images.