### PR TITLE
[OPS-5712] Configure syslog where it counts, so we get PHP logs in ELK.

### DIFF
--- a/alpine-base-php/php7/Dockerfile.tmpl
+++ b/alpine-base-php/php7/Dockerfile.tmpl
@@ -30,6 +30,7 @@ LABEL org.label-schema.schema-version="1.0" \
 
 # Default PHP configuration variables. These can be overridden via the environment.
 ENV PHP_ENVIRONMENT=production \
+    PHP_SYSLOG_FACILITY=LOG_LOCAL2 \
     PHP_ERROR_LOG=syslog \
     PHP_RUN_USER=appuser \
     PHP_RUN_GROUP=appuser \

--- a/alpine-base-php/php7/Dockerfile.tmpl
+++ b/alpine-base-php/php7/Dockerfile.tmpl
@@ -30,7 +30,7 @@ LABEL org.label-schema.schema-version="1.0" \
 
 # Default PHP configuration variables. These can be overridden via the environment.
 ENV PHP_ENVIRONMENT=production \
-    PHP_SYSLOG_FACILITY=LOG_LOCAL2 \
+    PHP_SYSLOG_FACILITY=LOG_LOCAL4 \
     PHP_ERROR_LOG=syslog \
     PHP_RUN_USER=appuser \
     PHP_RUN_GROUP=appuser \

--- a/alpine-base-php/php7/etc/php7/conf.d/00_syslog.ini
+++ b/alpine-base-php/php7/etc/php7/conf.d/00_syslog.ini
@@ -1,0 +1,4 @@
+; Configure PHP logging for our ELK instance.
+[syslog]
+syslog.ident = ${HOSTNAME}
+syslog.facility = LOG_LOCAL2

--- a/alpine-base-php/php7/etc/php7/conf.d/00_syslog.ini
+++ b/alpine-base-php/php7/etc/php7/conf.d/00_syslog.ini
@@ -1,4 +1,4 @@
 ; Configure PHP logging for our ELK instance.
 [syslog]
 syslog.ident = ${HOSTNAME}
-syslog.facility = LOG_LOCAL2
+syslog.facility = ${PHP_SYSLOG_FACILITY}

--- a/alpine-php/php7/k8s/etc/nginx/nginx.conf
+++ b/alpine-php/php7/k8s/etc/nginx/nginx.conf
@@ -115,7 +115,11 @@ http {
   ## reinstate in case it has been somehow disabled for this
   ## particular server instance.
   ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
-  add_header X-XSS-Protection '1; mode=block';
+  map $upstream_http_x_xss_protection $xssprotection {
+      default   $upstream_http_x_xss_protection;
+      ""        "1; mode=block";
+   }
+   add_header X-XSS-Protection $xssprotection;
 
   ## Block MIME type sniffing on IE.
   add_header X-Content-Options nosniff;

--- a/alpine-php/php7/k8s/etc/nginx/nginx.conf
+++ b/alpine-php/php7/k8s/etc/nginx/nginx.conf
@@ -95,7 +95,7 @@ http {
   gzip_comp_level 1;
   gzip_http_version 1.1;
   gzip_min_length 10;
-  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf;
+  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf image/svg+xml;
   gzip_vary on;
   gzip_proxied any; # Compression for all requests.
   ## No need for regexps.

--- a/alpine-php/php7/reliefweb/Dockerfile.tmpl
+++ b/alpine-php/php7/reliefweb/Dockerfile.tmpl
@@ -2,13 +2,14 @@ FROM unocha/php7:%%UPSTREAM%%
 
 MAINTAINER orakili <docker@orakili.net>
 
-ENV PHP_HOEDOWN_VERSION=0.6.8
-
 # A little bit of metadata management.
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_URL
 ARG VCS_REF
+
+# Set the hoedown version via a build argument.
+ARG PHP_HOEDOWN_VERSION
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.build-date=$BUILD_DATE \
@@ -58,7 +59,7 @@ RUN mv -f /run_fpm /etc/services.d/fpm/run && \
       tar && \
     cd /tmp && \
     # Build and install php-ext-hoedown.
-    git clone --recursive --depth=1 --branch=$PHP_HOEDOWN_VERSION https://github.com/UN-OCHA/rwint-php-ext-hoedown.git /tmp/php-ext-hoedown && \
+    git clone --recursive --depth=1 --branch=${PHP_HOEDOWN_VERSION} https://github.com/UN-OCHA/rwint-php-ext-hoedown.git /tmp/php-ext-hoedown && \
     cd /tmp/php-ext-hoedown && \
     phpize && ./configure && make && make test && make install && \
     cd /tmp && rm -rf /tmp/php* && \

--- a/alpine-php/php7/reliefweb/Makefile
+++ b/alpine-php/php7/reliefweb/Makefile
@@ -4,6 +4,7 @@ include ../../Makefile.conf
 UPSTREAM=$$(UPSTREAM))
 VERSION=$$(VERSION))
 IMAGE=php7-reliefweb
+EXTRAOPTIONS=--build-arg PHP_HOEDOWN_VERSION=$(PHP_HOEDOWN_VERSION)
 
 all: template build tag clean_images
 


### PR DESCRIPTION
After some fiddling on hidblog, it turns out that the settings in php-fpm.conf are ignored (or not passed on) and these settings *must* live under a [syslog] section in a global ini file.