### PR TITLE
[OPS-6379] Disable forced https redirection on hostname basis in php k8s image

### DIFF
--- a/alpine-php/php7/k8s/etc/nginx/lua/nginx_https_redir.lua
+++ b/alpine-php/php7/k8s/etc/nginx/lua/nginx_https_redir.lua
@@ -1,8 +1,11 @@
 if ngx.var.http_x_forwarded_proto == "https" then
   return 0
 end
-ngx.ctx.override_protocol_redirect = os.getenv("NGINX_OVERRIDE_PROTOCOL")
-if ngx.ctx.override_protocol_redirect == "HTTP" then
-  return 0
+http_host = ngx.var.http_host:lower()
+for name in os.getenv("NGINX_OVERRIDE_PROTOCOL"):gmatch("[^,]+") do
+  name = name:gsub("\"", ""):gsub("%s+", ""):lower()
+  if name == http_host or name == "HTTP" then
+    return 0
+  end
 end
 return 1


### PR DESCRIPTION
JIRA: https://humanitarian.atlassian.net/browse/OPS-6379

This allows to bypass the forced https redirection on a hostname basis while preserving compatibility with the current `NGINX_OVERRIDE_PROTOCOL=HTTP` usage.

This is notably useful for the RW stage sites that use internal hostname for communication with the RW API.