### PR TITLE
[OPS-6379] Be nice when no HTTPS redirect exceptions are defined.

### DIFF
--- a/alpine-php/php7/k8s/etc/nginx/lua/nginx_https_redir.lua
+++ b/alpine-php/php7/k8s/etc/nginx/lua/nginx_https_redir.lua
@@ -1,6 +1,13 @@
+-- If we are being accessed via https, no redirect is needed.
 if ngx.var.http_x_forwarded_proto == "https" then
   return 0
 end
+-- If we are not accessed via https, and no exceptions are set, redirect.
+if os.getenv("NGINX_OVERRIDE_PROTOCOL") == nil then
+  return 1
+end
+-- Check the current hostname against the list of redirect exceptions.
+-- If the hostname is listed or there is a global override, no redirect is needed.
 http_host = ngx.var.http_host:lower()
 for name in os.getenv("NGINX_OVERRIDE_PROTOCOL"):gmatch("[^,]+") do
   name = name:gsub("\"", ""):gsub("%s+", ""):lower()
@@ -8,4 +15,5 @@ for name in os.getenv("NGINX_OVERRIDE_PROTOCOL"):gmatch("[^,]+") do
     return 0
   end
 end
+-- Redirect.
 return 1

--- a/alpine-php/php7/k8s/etc/nginx/lua/nginx_servername_main.lua
+++ b/alpine-php/php7/k8s/etc/nginx/lua/nginx_servername_main.lua
@@ -1,6 +1,9 @@
+-- Initialise a new internal variable for the defined hostnames.
 ngx.ctx.host_name_list = {}
+-- Loop through the environment variable and make a list of allowed hostnames.
 for name in os.getenv("NGINX_SERVERNAME"):gmatch("[^,]+") do
   name = name:gsub("\"", ""):gsub("%s+", ""):lower()
   table.insert(ngx.ctx.host_name_list, name)
 end
+-- Return the first (= main) defined hostname.
 return ngx.ctx.host_name_list[1]

--- a/alpine-php/php7/k8s/etc/nginx/lua/nginx_servername_redir.lua
+++ b/alpine-php/php7/k8s/etc/nginx/lua/nginx_servername_redir.lua
@@ -1,7 +1,10 @@
+-- Grab a lowercase version of the current hostname.
 http_host = ngx.var.http_host:lower()
+-- If the current hostname is in the list of allowed hostnames, do not redirect.
 for i = 1, #ngx.ctx.host_name_list do
   if ngx.ctx.host_name_list[i] == http_host then
     return 0
   end
 end
+-- The current hostname is not listed, redirect to the main hostname.
 return 1


### PR DESCRIPTION
Do also just comment our code. That is nice for future $me and future $you.

I should note, without that check for an empty env var, nginx throws a 500 if the var is not set.

I've already build `-202004-02` images off this branch.