### PR TITLE
[OPS-6486] Implement a hotfix to make iconv() work on Alpine/MUSL.

### DIFF
--- a/alpine-base-php/php7/Dockerfile.tmpl
+++ b/alpine-base-php/php7/Dockerfile.tmpl
@@ -43,7 +43,10 @@ ENV PHP_ENVIRONMENT=production \
     PHP_MAX_EXECUTION_TIME=60s \
     PHP_POST_MAX_SIZE=100m \
     PHP_UPLOAD_MAX_FILESIZE=100m \
-    PHP_MAX_INPUT_VARS=1000
+    PHP_MAX_INPUT_VARS=1000 \
+    # Oh, this is hideous, but it does solve the iconv problem.
+    # See https://humanitarian.atlassian.net/browse/OPS-6486
+    LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 # Copy custom config files into the container.
 COPY etc/php7 etc/services/run_fpm etc/msmtprc /tmp/
@@ -53,6 +56,7 @@ RUN \
     apk -U upgrade && \
     apk add --update-cache \
       fcgi \
+      gnu-libiconv \
       imagemagick \
       msmtp \
       php7-bcmath \


### PR DESCRIPTION
This adds the GNU libiconv library and sets LD_PRELOAD globally, to
ensure its functions are always present. Since the container *only*
runs nginx and PHP, this should be OK.

See https://github.com/docker-library/php/issues/240