### PR TITLE
[OPS-6736] Fix ownership on the nginx tmp dir, so apps can upload.

### DIFF
--- a/alpine-php/php7/k8s/Dockerfile.tmpl
+++ b/alpine-php/php7/k8s/Dockerfile.tmpl
@@ -14,7 +14,7 @@ ARG BUILD_DATE
 ENV NGINX_SERVERNAME=localhost \
     PAGER=more \
     LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
-    PS1="\u@\h:\w\n "
+    PS1="\u@\h:\w\n\$ "
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.build-date=$BUILD_DATE \

--- a/alpine-php/php7/k8s/Dockerfile.tmpl
+++ b/alpine-php/php7/k8s/Dockerfile.tmpl
@@ -12,7 +12,9 @@ ARG VCS_REF
 ARG BUILD_DATE
 
 ENV NGINX_SERVERNAME=localhost \
-    PAGER=more
+    PAGER=more \
+    LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
+    PS1="\u@\h:\w\n "
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.build-date=$BUILD_DATE \
@@ -46,8 +48,8 @@ RUN \
        /tmp/lua /tmp/sites-enabled /tmp/win-utf \
          /etc/nginx && \
     mv /tmp/run_nginx /etc/services.d/nginx/run && \
-    mkdir -p  /var/cache/nginx && \
-    chown appuser:root /var/cache/nginx /var/tmp/nginx && \
+    mkdir -p /var/cache/nginx && \
+    chown -R appuser:root /var/cache/nginx /var/lib/nginx/tmp && \
     rm -rf /var/cache/apk/* && \
     \
     # Update the fpm pool config to use a socket.

--- a/alpine-php/php7/k8s/Dockerfile.tmpl
+++ b/alpine-php/php7/k8s/Dockerfile.tmpl
@@ -49,7 +49,8 @@ RUN \
          /etc/nginx && \
     mv /tmp/run_nginx /etc/services.d/nginx/run && \
     mkdir -p /var/cache/nginx && \
-    chown -R appuser:root /var/cache/nginx /var/lib/nginx/tmp && \
+    chgrp appuser /var/lib/nginx && \
+    chown -R appuser /var/cache/nginx /var/lib/nginx/tmp && \
     rm -rf /var/cache/apk/* && \
     \
     # Update the fpm pool config to use a socket.


### PR DESCRIPTION
Also make sure the iconv LD_PRELOASD fix goes in. I'm not sure if we
need it, with the changed charset (UTF-8 vs UTF8) but lets err on the
side of caution. Additionally, set the PS1 prompt.