### PR TITLE
[OPS-6833] Add mupdf to the php image

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -26,6 +26,7 @@ build: clean template
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg UPSTREAM=$(UPSTREAM) \
+		--tag $(ORGANISATION)/$(IMAGE):$(VERSION)$(EXTRAVERSION) \
 		$(EXTRAOPTIONS) \
 		. 2>&1 | tee buildlog.txt
 

--- a/alpine-base-nodejs/Dockerfile.tmpl
+++ b/alpine-base-nodejs/Dockerfile.tmpl
@@ -20,8 +20,9 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.description="This service provides a base nodejs platform." \
       org.label-schema.architecture="x86_64" \
       org.label-schema.distribution="Alpine Linux" \
-      org.label-schema.distribution-version="3.6" \
-      info.humanitarianresponse.nodejs="6.11.4-r0"
+      org.label-schema.distribution-version="3.12" \
+      info.humanitarianresponse.nodejs="12.18.2" \
+      info.humanitarianresponse.python="3.8.5-r0"
 
 ENV NODE_APP_DIR=/srv/www \
     NODE_PATH=/usr/lib/node_modules \
@@ -37,20 +38,20 @@ ENV NODE_APP_DIR=/srv/www \
 RUN apk add --update-cache \
         build-base \
         git \
-        python && \
+        python3 && \
     apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
         nodejs \
         nodejs-npm && \
-    mkdir -p /root/.node-gyp/6.11.4 && \
-    USER=root npm install -g \
+    mkdir -p /root/.cache/node-gyp/12.18.2 && \
+    USER=root npm --force --cache /tmp/empty-cache install -g \
         grunt-cli \
         bower \
         newrelic \
         webpack \
         yarn && \
-    npm cache clean && \
-    rm -rf /tmp /root/.node-gyp && \
+    npm --force cache clean && \
     apk del build-base && \
+    rm -rf /tmp /root/.node-gyp && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /tmp && \
     chmod 1777 /tmp && \

--- a/alpine-base-php/php7-newrelic/Dockerfile.tmpl
+++ b/alpine-base-php/php7-newrelic/Dockerfile.tmpl
@@ -27,7 +27,7 @@ LABEL org.label-schema.schema-version="1.0" \
       info.humanitarianresponse.php.modules="bcmath bz2 calendar ctype curl dom exif fileinfo fpm gd geos gettext iconv imagick json mcrypt memcached newrelic opcache openssl pdo pdo_mysql phar posix redis shmop sysvmsg sysvsem sysvshm simplexml sockets wddx xml xmlreader xmlwriter xsl zip zlib" \
       info.humanitarianresponse.php.sapi="fpm"
 
-ENV NR_VERSION 9.9.0.260
+ENV NR_VERSION 9.12.0.268
 
 ENV PHP_NEWRELIC_LICENSE="" \
     PHP_NEWRELIC_APPNAME=""

--- a/alpine-base-php/php7/Dockerfile.tmpl
+++ b/alpine-base-php/php7/Dockerfile.tmpl
@@ -57,11 +57,12 @@ ENV PS1="\u@\h:\w\n\$ " \
 COPY etc/php7 etc/services/run_fpm etc/msmtprc /tmp/
 
 RUN \
+    echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     # Install standard packages from $UPSTREAM.
     apk -U upgrade && \
     apk add --update-cache \
       fcgi \
-      gnu-libiconv \
+      gnu-libiconv@edgecommunity \
       imagemagick \
       msmtp \
       php7-bcmath \

--- a/alpine-base-php/php7/Dockerfile.tmpl
+++ b/alpine-base-php/php7/Dockerfile.tmpl
@@ -46,7 +46,11 @@ ENV PHP_ENVIRONMENT=production \
     PHP_MAX_INPUT_VARS=1000 \
     # Oh, this is hideous, but it does solve the iconv problem.
     # See https://humanitarian.atlassian.net/browse/OPS-6486
-    LD_PRELOAD=/usr/lib/preloadable_libiconv.so
+    LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
+    # Specify a mupdf version for ReliefWeb.
+    # This needs to be built from source, as the Alpine edge version has library depend issues on the "old" PHP7.2 :-)
+    # See https://humanitarian.atlassian.net/browse/OPS-6833
+    MUPDF_VERSION=1.17.0
 
 # Copy custom config files into the container.
 COPY etc/php7 etc/services/run_fpm etc/msmtprc /tmp/
@@ -138,6 +142,12 @@ RUN \
         cd .. && \
       rm -rf phpredis && \
       rm -rf /usr/include/php/ && \
+    # Build and install mupdf tools.
+    cd /tmp && \
+      git clone --branch=$MUPDF_VERSION --recursive git://git.ghostscript.com/mupdf.git && \
+      cd mupdf && git submodule update --init && \
+        make HAVE_X11=no HAVE_GLUT=no USE_SYSTEM_LIBS=no prefix=/usr/local install && \
+      cd /tmp && rm -rf /tmp/mupdf* && \
     apk del .build-dependencies && \
     # Install igbinary.
     apk add php7-pecl-igbinary && \

--- a/alpine-base-php/php7/Dockerfile.tmpl
+++ b/alpine-base-php/php7/Dockerfile.tmpl
@@ -29,7 +29,8 @@ LABEL org.label-schema.schema-version="1.0" \
       info.humanitarianresponse.php.sapi="fpm"
 
 # Default PHP configuration variables. These can be overridden via the environment.
-ENV PHP_ENVIRONMENT=production \
+ENV PS1="\u@\h:\w\n\$ " \
+    PHP_ENVIRONMENT=production \
     PHP_SYSLOG_FACILITY=LOG_LOCAL4 \
     PHP_ERROR_LOG=syslog \
     PHP_RUN_USER=appuser \

--- a/alpine-base-s6/Dockerfile.tmpl
+++ b/alpine-base-s6/Dockerfile.tmpl
@@ -6,7 +6,7 @@ ARG VCS_URL
 ARG VCS_REF
 ARG BUILD_DATE
 
-ARG S6_VERSION=v1.22.1.0
+ARG S6_VERSION=v2.0.0.1
 
 # A little bit of metadata management.
 # See http://label-schema.org/

--- a/alpine-nodejs-builder/Dockerfile.tmpl
+++ b/alpine-nodejs-builder/Dockerfile.tmpl
@@ -20,10 +20,10 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.description="This service provides a builder container for node." \
       org.label-schema.architecture="x86_64" \
       org.label-schema.distribution="Alpine Linux" \
-      org.label-schema.distribution-version="3.6" \
-      info.humanitarianresponse.node="6.11.4" \
-      info.humanitarianresponse.npm="3.10.10" \
-      info.humanitarianresponse.ruby="2.3.1"
+      org.label-schema.distribution-version="3.12" \
+      info.humanitarianresponse.node="12.18.2" \
+      info.humanitarianresponse.npm="12.18.2" \
+      info.humanitarianresponse.ruby="2.7.1-r3"
 
 ENV DST_DIR=/dst
 

--- a/alpine-php/php7/Dockerfile.tmpl
+++ b/alpine-php/php7/Dockerfile.tmpl
@@ -13,7 +13,6 @@ ARG BUILD_DATE
 ENV DRUSH_VERSION=8 \
     DRUSH_RELEASE=8.1.15 \
     WP_RELEASE=2.1.0 \
-    MUPDF_VERSION=1.17.0 \
     PAGER=more
 
 LABEL org.label-schema.schema-version="1.0" \
@@ -72,15 +71,5 @@ RUN apk add --update-cache \
       composer global require wp-cli/wp-cli:$WP_RELEASE && \
     ln -sf /usr/local/wp$WP_RELEASE/vendor/wp-cli/wp-cli/bin/wp /usr/bin/wp && \
     wp --info && \
-    # Install dependencies to build mupdf tools.
-    apk add --virtual .build-dependencies build-base && \
-    cd /tmp && \
-    # Build and install mupdf tools.
-    git clone --branch=$MUPDF_VERSION --recursive git://git.ghostscript.com/mupdf.git && \
-    cd mupdf && git submodule update --init && \
-    make HAVE_X11=no HAVE_GLUT=no USE_SYSTEM_LIBS=no prefix=/usr/local install && \
-    cd /tmp && rm -rf /tmp/mupdf* && \
-    # Remove build dependencies.
-    apk del .build-dependencies && \
     # Clear the cache to reduce the layer size.
     rm -rf /var/cache/apk/*

--- a/alpine-php/php7/Dockerfile.tmpl
+++ b/alpine-php/php7/Dockerfile.tmpl
@@ -13,6 +13,7 @@ ARG BUILD_DATE
 ENV DRUSH_VERSION=8 \
     DRUSH_RELEASE=8.1.15 \
     WP_RELEASE=2.1.0 \
+    MUPDF_VERSION=1.17.0 \
     PAGER=more
 
 LABEL org.label-schema.schema-version="1.0" \
@@ -70,4 +71,16 @@ RUN apk add --update-cache \
     COMPOSER_HOME=/usr/local/wp$WP_RELEASE  \
       composer global require wp-cli/wp-cli:$WP_RELEASE && \
     ln -sf /usr/local/wp$WP_RELEASE/vendor/wp-cli/wp-cli/bin/wp /usr/bin/wp && \
-    wp --info
+    wp --info && \
+    # Install dependencies to build mupdf tools.
+    apk add --virtual .build-dependencies build-base && \
+    cd /tmp && \
+    # Build and install mupdf tools.
+    git clone --branch=$MUPDF_VERSION --recursive git://git.ghostscript.com/mupdf.git && \
+    cd mupdf && git submodule update --init && \
+    make HAVE_X11=no HAVE_GLUT=no USE_SYSTEM_LIBS=no prefix=/usr/local install && \
+    cd /tmp && rm -rf /tmp/mupdf* && \
+    # Remove build dependencies.
+    apk del .build-dependencies && \
+    # Clear the cache to reduce the layer size.
+    rm -rf /var/cache/apk/*

--- a/alpine-php/php7/builder/Dockerfile.tmpl
+++ b/alpine-php/php7/builder/Dockerfile.tmpl
@@ -23,20 +23,21 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.description="This service provides a builder container for PHP, with node and sass helpers." \
       org.label-schema.architecture="x86_64" \
       org.label-schema.distribution="Alpine Linux" \
-      org.label-schema.distribution-version="3.10.2" \
+      org.label-schema.distribution-version="3.12" \
       info.humanitarianresponse.php=$VERSION \
       info.humanitarianresponse.php.modules="bcmath bz2 calendar ctype curl dom exif fileinfo fpm ftp gd gettext iconv igbinary imagick imap intl json mcrypt memcached opcache openssl pdo pdo_mysql phar posix redis shmop soap sysvmsg sysvsem sysvshm simplexml sockets wddx xml xmlreader xmlwriter xsl zip zlib" \
       info.humanitarianresponse.php.sapi="cli" \
       info.humanitarianresponse.composer="1.8.4" \
       info.humanitarianresponse.drush="8.1.18-dev" \
-      info.humanitarianresponse.node="8.11.3" \
-      info.humanitarianresponse.npm="6.9.0" \
+      info.humanitarianresponse.node="12.18" \
+      info.humanitarianresponse.npm="12.18" \
       info.humanitarianresponse.yarn="1.7.0" \
       info.humanitarianresponse.compass="3.2.0" \
       info.humanitarianresponse.jasmine="3.4.0" \
       info.humanitarianresponse.casperjs="1.1.3" \
       info.humanitarianresponse.phantomjs="2.0.0" \
-      info.humanitarianresponse.ruby="2.3.1"
+      info.humanitarianresponse.python="3.8.5" \
+      info.humanitarianresponse.ruby="2.3.7"
 
 ENV DRUSH_VERSION=8 \
     DRUSH_RELEASE=8.x-dev
@@ -130,12 +131,11 @@ RUN npm install --global npm@latest && \
     # Add dependencies for capsper and phantom.
     apk add --update-cache \
       fontconfig \
-      libc6-compat \
-      python && \
+      libc6-compat && \
     rm -rf /var/cache/apk/* && \
     # Install casper.
     curl -L -o /tmp/casperjs.zip https://github.com/n1k0/casperjs/archive/master.zip && \
-    mkdir /opt && \
+    mkdir -p /opt && \
     unzip /tmp/casperjs.zip -d /opt && \
     mv /opt/casperjs-master /opt/casperjs && \
     ln -s /opt/casperjs/bin/casperjs /usr/local/bin/casperjs && \

--- a/alpine-php/php7/k8s/Dockerfile.tmpl
+++ b/alpine-php/php7/k8s/Dockerfile.tmpl
@@ -48,9 +48,9 @@ RUN \
        /tmp/lua /tmp/sites-enabled /tmp/win-utf \
          /etc/nginx && \
     mv /tmp/run_nginx /etc/services.d/nginx/run && \
-    mkdir -p /var/cache/nginx && \
+    mkdir -p /var/cache/nginx /var/lib/nginx/tmp /var/tmp/nginx && \
     chgrp appuser /var/lib/nginx && \
-    chown -R appuser /var/cache/nginx /var/lib/nginx/tmp && \
+    chown -R appuser /var/cache/nginx /var/lib/nginx/tmp /var/tmp/nginx && \
     rm -rf /var/cache/apk/* && \
     \
     # Update the fpm pool config to use a socket.

--- a/alpine-php/php7/k8s/etc/nginx/lua/nginx_https_redir.lua
+++ b/alpine-php/php7/k8s/etc/nginx/lua/nginx_https_redir.lua
@@ -8,10 +8,11 @@ if os.getenv("NGINX_OVERRIDE_PROTOCOL") == nil then
 end
 -- Check the current hostname against the list of redirect exceptions.
 -- If the hostname is listed or there is a global override, no redirect is needed.
+-- Do not lowercase all listed exceptions, or the uppercase HTTP override will fail.
 http_host = ngx.var.http_host:lower()
 for name in os.getenv("NGINX_OVERRIDE_PROTOCOL"):gmatch("[^,]+") do
-  name = name:gsub("\"", ""):gsub("%s+", ""):lower()
-  if name == http_host or name == "HTTP" then
+  name = name:gsub("\"", ""):gsub("%s+", "")
+  if name:lower() == http_host or name == "HTTP" then
     return 0
   end
 end


### PR DESCRIPTION
JIRA ticket: https://humanitarian.atlassian.net/browse/OPS-6833

This adds the mupdf building to the php image instead of the image for the reliefweb site as it takes several minutes to build, in order to avoid excessive github actions minutes usage when building new reliefweb images.

This could be added to the `alpine-base-php` image instead. Not sure which is best. What do you think @cafuego?