### PR TITLE
[OPS-6844] Add cron dependency to hubot

### DIFF
--- a/alpine-hubot/package.json
+++ b/alpine-hubot/package.json
@@ -5,6 +5,7 @@
   "author": "Peter Droogmans <peter@attiks.com>",
   "description": "A simple helpful robot for your Company",
   "dependencies": {
+    "cron": "^1.8.2",
     "hubot": "^2.19.0",
     "hubot-auth": "^2.0.0",
     "hubot-brain-inspect": "0.0.1",


### PR DESCRIPTION
Ticket: https://humanitarian.atlassian.net/browse/OPS-6844

This is the sister PR of https://github.com/UN-OCHA/jebbbot/pull/39 to add the `cron` dependency.