### PR TITLE
[OPS-7190] Ensure that mysqli loads. And load after mysqlnd, as it depends on it.

### DIFF
--- a/alpine-base-php/php7/etc/php7/conf.d/02_mysqli.ini
+++ b/alpine-base-php/php7/etc/php7/conf.d/02_mysqli.ini
@@ -1,0 +1,1 @@
+extension=mysqli.so


### PR DESCRIPTION
This is an issue for WCA. Currently hotfixed by dropping the ini file in /etc/php7/conf.d/ in the wca site repo.  Probably also the source of all pain with wordpress.

https://github.com/UN-OCHA/weekly-wca-microsite/pull/74/files