### PR TITLE
[OPS-7303] Where is xdebug?

### DIFF
--- a/alpine-base-php/php7/Dockerfile.tmpl
+++ b/alpine-base-php/php7/Dockerfile.tmpl
@@ -45,6 +45,18 @@ ENV PS1="\u@\h:\w\n\$ " \
     PHP_POST_MAX_SIZE=100m \
     PHP_UPLOAD_MAX_FILESIZE=100m \
     PHP_MAX_INPUT_VARS=1000 \
+    # Allow developers to disable opcache, so local changes show up immediately.
+    # See https://humanitarian.atlassian.net/browse/OPS-7156
+    PHP_OPCACHE_ENABLE=1 \
+    PHP_OPCACHE_REVALIDATE_FREQ=300 \
+    # Allow developers to use and configure xdebug.
+    PHP_XDEBUG=false \
+    PHP_XDEBUG_REMOTE_HOST=127.0.0.1 \
+    PHP_XDEBUG_REMOTE_AUTOSTART=0 \
+    PHP_XDEBUG_REMOTE_ENABLE=0 \
+    PHP_XDEBUG_REMOTE_PORT=9001 \
+    PHP_XDEBUG_DEFAULT_ENABLE=0 \
+    PHP_XDEBUG_REMOTE_CONNECT_BACK=0 \
     # Oh, this is hideous, but it does solve the iconv problem.
     # See https://humanitarian.atlassian.net/browse/OPS-6486
     LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
@@ -108,6 +120,7 @@ RUN \
       php7-xsl \
       php7-zip \
       php7-zlib \
+      php7-pecl-xdebug \
       pngquant && \
     # Tidy.
     rm -rf /var/cache/apk/* && \

--- a/alpine-base-php/php7/etc/php7/conf.d/00_opcache.ini
+++ b/alpine-base-php/php7/etc/php7/conf.d/00_opcache.ini
@@ -1,8 +1,8 @@
 zend_extension=opcache.so
 
-opcache.enable=1
+opcache.enable=${PHP_OPCACHE_ENABLE}
 opcache.memory_consumption=128
 opcache.interned_strings_buffer=8
 opcache.max_accelerated_files=16000
-opcache.revalidate_freq=300
+opcache.revalidate_freq=${PHP_OPCACHE_REVALIDATE_FREQ}
 opcache.fast_shutdown=1

--- a/alpine-base-php/php7/etc/php7/conf.d/30_xdebug.ini
+++ b/alpine-base-php/php7/etc/php7/conf.d/30_xdebug.ini
@@ -1,0 +1,6 @@
+xdebug.remote_host             = ${PHP_XDEBUG_REMOTE_HOST}
+xdebug.remote_autostart        = ${PHP_XDEBUG_REMOTE_AUTOSTART}
+xdebug.remote_enable           = ${PHP_XDEBUG_REMOTE_ENABLE}
+xdebug.remote_port             = ${PHP_XDEBUG_REMOTE_PORT}
+xdebug.default_enable          = ${PHP_XDEBUG_DEFAULT_ENABLE}
+xdebug.remote_connect_back     = ${PHP_XDEBUG_REMOTE_CONNECT_BACK}

--- a/alpine-base-php/php7/etc/php7/environment.d/local.conf
+++ b/alpine-base-php/php7/etc/php7/environment.d/local.conf
@@ -1,0 +1,4 @@
+; Configuration specific to local environments.
+php_flag[display_errors] = On
+php_flag[display_startup_errors] = On
+php_flag[opcache.enable] = Off

--- a/alpine-base-php/php7/etc/services/run_fpm
+++ b/alpine-base-php/php7/etc/services/run_fpm
@@ -1,4 +1,8 @@
 #!/usr/bin/with-contenv sh
 set -e
 
-exec /usr/sbin/php-fpm7 -c /etc/php7/php.ini -y /etc/php7/php-fpm.conf -F
+if [ "${PHP_XDEBUG}" = "true" ]; then
+  exec /usr/sbin/php-fpm7 -c /etc/php7/php.ini -d zend_extension=xdebug.so -y /etc/php7/php-fpm.conf -F
+else
+  exec /usr/sbin/php-fpm7 -c /etc/php7/php.ini -y /etc/php7/php-fpm.conf -F
+fi


### PR DESCRIPTION
* Found it: `grep "xdebug" $(git rev-list --all); git branch --contains commmit-sh`
* Hey, this is also where the opcache control work is.