### PR TITLE
[SECURITY][CERF-221] Block access to Drupal 8 system files (composer et al)

### DIFF
--- a/alpine-php/php7-k8s/etc/nginx/apps/drupal/drupal.conf
+++ b/alpine-php/php7-k8s/etc/nginx/apps/drupal/drupal.conf
@@ -233,7 +233,13 @@ location / {
     ## Replicate the Apache <FilesMatch> directive of Drupal standard
     ## .htaccess. Disable access to any code files. Return a 404 to curtail
     ## information disclosure. Hide also the text files.
-    location ~* ^(?:.+\.(?:htaccess|make|txt|engine|inc|info|install|module|profile|po|pot|sh|.*sql|test|theme|tpl(?:\.php)?|xtmpl)|code-style\.pl|/Entries.*|/Repository|/Root|/Tag|/Template)$ {
+    ## And amend the list with Drupal 8/9/10 yaml files.
+    location ~* ^(?:.+\.(?:htaccess|make|txt|engine|inc|info|install|module|profile|po|pot|sh|.*sql|test|theme|twig|tpl(?:\.php)?|xtmpl|yaml|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?|code-style\.pl|/Entries.*|/Repository|/Root|/Tag|/Template|)$ {
+        return 404;
+    }
+
+    ## Extend the list with Drupal 8/9/10 composer files and the rest of the new shipped .htaccess list :-)
+    location ~* (composer\.(json|lock)|web\.config)|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
         return 404;
     }
 
@@ -300,6 +306,10 @@ location ^~ /.svn {
 location ^~ /.cvs {
     return 404;
 }
+
+## Disallow acess to composer.(json|lock|patches) files.
+location ^~ /composer.json {
+    return 404;
 
 ## Disallow access to patches directory.
 location ^~ /patches {


### PR DESCRIPTION
Once approved, I will hotfix the current -stable and -develop docker images, so any new deploys will include these fixes without doing version bumps.

Source list of file extensions at https://git.drupalcode.org/project/drupal/-/blob/9.2.x/.htaccess#L6