### PR TITLE
[OPS-7740] Configurable bot rate limits

### DIFF
--- a/alpine-php/php-k8s-v7/Dockerfile.tmpl
+++ b/alpine-php/php-k8s-v7/Dockerfile.tmpl
@@ -12,6 +12,10 @@ ARG VCS_REF
 ARG BUILD_DATE
 
 ENV NGINX_SERVERNAME=localhost \
+    NGINX_LIMIT_BOTS=2r/m \
+    NGINX_BURST_BOTS=2 \
+    NGINX_LIMIT_HUMANS=16r/s \
+    NGINX_BURST_HUMANS=16 \
     PAGER=more \
     PATH=/srv/www/vendor/bin:$PATH \
     LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
@@ -41,7 +45,7 @@ RUN \
     mkdir -p /etc/services.d/nginx && \
     rm -rf /etc/nginx/* && \
     mv /tmp/apps /tmp/fastcgi.conf /tmp/koi-utf /tmp/map_block_http_methods.conf /tmp/mime.types /tmp/upstream_phpcgi_unix.conf \
-       /tmp/blacklist.conf /tmp/fastcgi_params /tmp/koi-win /tmp/map_https_fcgi.conf /tmp/nginx.conf \
+       /tmp/blacklist.conf /tmp/ratelimit.conf /tmp/fastcgi_params /tmp/koi-win /tmp/map_https_fcgi.conf /tmp/nginx.conf \
        /tmp/lua /tmp/sites-enabled /tmp/win-utf \
          /etc/nginx && \
     mv /tmp/run_nginx /etc/services.d/nginx/run && \

--- a/alpine-php/php-k8s-v7/Dockerfile.tmpl
+++ b/alpine-php/php-k8s-v7/Dockerfile.tmpl
@@ -41,11 +41,11 @@ COPY etc/drush/drushrc.php \
 
 # Install NGINX for standard operation.
 RUN \
-    apk add -U nginx nginx-mod-http-upload-progress nginx-mod-http-lua && \
+    apk add -U gettext nginx nginx-mod-http-upload-progress nginx-mod-http-lua && \
     mkdir -p /etc/services.d/nginx && \
     rm -rf /etc/nginx/* && \
     mv /tmp/apps /tmp/fastcgi.conf /tmp/koi-utf /tmp/map_block_http_methods.conf /tmp/mime.types /tmp/upstream_phpcgi_unix.conf \
-       /tmp/blacklist.conf /tmp/ratelimit.conf /tmp/fastcgi_params /tmp/koi-win /tmp/map_https_fcgi.conf /tmp/nginx.conf \
+       /tmp/blacklist.conf /tmp/ratelimit.conf /tmp/ratelimit.conf.template /tmp/fastcgi_params /tmp/koi-win /tmp/map_https_fcgi.conf /tmp/nginx.conf \
        /tmp/lua /tmp/sites-enabled /tmp/win-utf \
          /etc/nginx && \
     mv /tmp/run_nginx /etc/services.d/nginx/run && \

--- a/alpine-php/php-k8s-v7/etc/nginx/nginx.conf
+++ b/alpine-php/php-k8s-v7/etc/nginx/nginx.conf
@@ -23,7 +23,15 @@ env NGINX_SERVERNAME;
 ## Allow protocol redirect bypass.
 env NGINX_OVERRIDE_PROTOCOL;
 
-## Need LUA to determine the correct server_name.
+## A default rate limit and burst rate for bots.
+env NGINX_LIMIT_BOTS;
+env NGINX_BURST_BOTS;
+
+## A default rate limit and burst for humans.
+env NGINX_LIMIT_HUMANS;
+env NGINX_BURST_HUMANS;
+
+## Need LUA to determine the correct server_name and do rate limiting.
 load_module /var/lib/nginx/modules/ndk_http_module.so;
 load_module /var/lib/nginx/modules/ngx_http_lua_module.so;
 
@@ -85,7 +93,6 @@ http {
   ## Optimization of socket handling when using sendfile.
   tcp_nopush on;
 
-
   ## Compression.
   gzip on;
   gzip_buffers 16 8k;
@@ -142,6 +149,9 @@ http {
 
   ## Include blacklist for bad bot and referer blocking.
   include /etc/nginx/blacklist.conf;
+
+  ## Rate limiting. Limits are per remote IP address per backend.
+  include /etc/nginx/ratelimit.conf;
 
   ## Include the caching setup. Needed for using Drupal with an external cache.
   include apps/drupal/map_cache.conf;

--- a/alpine-php/php-k8s-v7/etc/nginx/nginx.conf
+++ b/alpine-php/php-k8s-v7/etc/nginx/nginx.conf
@@ -23,15 +23,7 @@ env NGINX_SERVERNAME;
 ## Allow protocol redirect bypass.
 env NGINX_OVERRIDE_PROTOCOL;
 
-## A default rate limit and burst rate for bots.
-env NGINX_LIMIT_BOTS;
-env NGINX_BURST_BOTS;
-
-## A default rate limit and burst for humans.
-env NGINX_LIMIT_HUMANS;
-env NGINX_BURST_HUMANS;
-
-## Need LUA to determine the correct server_name and do rate limiting.
+## Need LUA to determine the correct server_name.
 load_module /var/lib/nginx/modules/ndk_http_module.so;
 load_module /var/lib/nginx/modules/ngx_http_lua_module.so;
 

--- a/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf
+++ b/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf
@@ -3,8 +3,8 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default         0;
-        ~*(bot|crawler) 1;
+        default                0;
+        ~*(bot|crawler|spider) 1;
 }
 
 ## Set a limit zone based on the bot status.

--- a/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf
+++ b/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf
@@ -1,0 +1,28 @@
+## Grab the rate limit settings from the environment.
+set_by_lua $nginx_limit_bots 'return os.getenv("NGINX_LIMIT_BOTS")';
+set_by_lua $nginx_burst_bots 'return os.getenv("NGINX_BURST_BOTS")';
+set_by_lua $nginx_limit_humans 'return os.getenv("NGINX_LIMIT_HUMANS")';
+set_by_lua $nginx_burst_humans 'return os.getenv("NGINX_BURST_HUMANS")';
+
+## A rate limit request returns status 429.
+limit_req_status 429;
+
+## Determine if this is a bot request via the user-agent string.
+map $http_user_agent $isbot_ua {
+        default         0;
+        ~*(bot|crawler) 1;
+}
+
+## Set a limit zone based on the bot status.
+map $isbot_ua $limit_bot {
+        0       "";
+        1       $binary_remote_addr;
+}
+
+## Apply the rate limits.
+limit_req_zone $limit_bot zone=bots:10m rate=$nginx_limit_bots;
+limit_req_zone $binary_remote_addr zone=humans:10m rate=$nginx_limit_humans;
+
+## Apply the burst limits.
+limit_req zone=bots burst=$nginx_burst_bots nodelay;
+limit_req zone=humans burst=$nginx_burst_humans nodelay;

--- a/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf.template
+++ b/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf.template
@@ -1,3 +1,5 @@
+## Apply settings from the environment at boot time via envsubst.
+
 ## A rate limit request returns status 429.
 limit_req_status 429;
 
@@ -14,9 +16,9 @@ map $isbot_ua $limit_bot {
 }
 
 ## Apply the rate limits.
-limit_req_zone $limit_bot zone=bots:10m rate=2r/m;
-limit_req_zone $binary_remote_addr zone=humans:10m rate=16r/s;
+limit_req_zone $limit_bot zone=bots:10m rate=${NGINX_LIMIT_BOTS};
+limit_req_zone $binary_remote_addr zone=humans:10m rate=${NGINX_LIMIT_HUMANS};
 
 ## Apply the burst limits.
-limit_req zone=bots burst=2 nodelay;
-limit_req zone=humans burst=16 nodelay;
+limit_req zone=bots burst=${NGINX_BURST_BOTS} nodelay;
+limit_req zone=humans burst=${NGINX_BURST_HUMANS} nodelay;

--- a/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf.template
+++ b/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf.template
@@ -5,8 +5,8 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default         0;
-        ~*(bot|crawler) 1;
+        default                0;
+        ~*(bot|crawler|spider) 1;
 }
 
 ## Set a limit zone based on the bot status.

--- a/alpine-php/php-k8s-v7/etc/services.d/run_nginx
+++ b/alpine-php/php-k8s-v7/etc/services.d/run_nginx
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv sh
 set -e
 
-exec nginx -g "daemon off;"
+envsubst '$NGINX_LIMIT_BOTS $NGINX_BURST_BOTS $NGINX_LIMIT_HUMANS $NGINX_BURST_HUMANS' < /etc/nginx/ratelimit.conf.template > /etc/nginx/ratelimit.conf && exec nginx -g "daemon off;"

--- a/alpine-php/php-k8s-v8/Dockerfile.tmpl
+++ b/alpine-php/php-k8s-v8/Dockerfile.tmpl
@@ -38,11 +38,11 @@ COPY etc/nginx/ etc/services.d/run_nginx \
 
 # Install NGINX for standard operation.
 RUN \
-    apk add -U nginx nginx-mod-http-upload-progress nginx-mod-http-lua && \
+    apk add -U gettext nginx nginx-mod-http-upload-progress nginx-mod-http-lua && \
     mkdir -p /etc/services.d/nginx && \
     rm -rf /etc/nginx/* && \
     mv /tmp/apps /tmp/fastcgi.conf /tmp/koi-utf /tmp/map_block_http_methods.conf /tmp/mime.types /tmp/upstream_phpcgi_unix.conf \
-       /tmp/blacklist.conf /tmp/ratelimit.conf /tmp/fastcgi_params /tmp/koi-win /tmp/map_https_fcgi.conf /tmp/nginx.conf \
+       /tmp/blacklist.conf /tmp/ratelimit.conf /tmp/ratelimit.conf.template /tmp/fastcgi_params /tmp/koi-win /tmp/map_https_fcgi.conf /tmp/nginx.conf \
        /tmp/lua /tmp/sites-enabled /tmp/win-utf \
          /etc/nginx && \
     mv /tmp/run_nginx /etc/services.d/nginx/run && \

--- a/alpine-php/php-k8s-v8/Dockerfile.tmpl
+++ b/alpine-php/php-k8s-v8/Dockerfile.tmpl
@@ -12,6 +12,10 @@ ARG VCS_REF
 ARG BUILD_DATE
 
 ENV NGINX_SERVERNAME=localhost \
+    NGINX_LIMIT_BOTS=2r/m \
+    NGINX_BURST_BOTS=2 \
+    NGINX_LIMIT_HUMANS=16r/s \
+    NGINX_BURST_HUMANS=16 \
     PAGER=more \
     PATH=/srv/www/vendor/bin:$PATH \
     LD_PRELOAD=/usr/lib/preloadable_libiconv.so \
@@ -38,7 +42,7 @@ RUN \
     mkdir -p /etc/services.d/nginx && \
     rm -rf /etc/nginx/* && \
     mv /tmp/apps /tmp/fastcgi.conf /tmp/koi-utf /tmp/map_block_http_methods.conf /tmp/mime.types /tmp/upstream_phpcgi_unix.conf \
-       /tmp/blacklist.conf /tmp/fastcgi_params /tmp/koi-win /tmp/map_https_fcgi.conf /tmp/nginx.conf \
+       /tmp/blacklist.conf /tmp/ratelimit.conf /tmp/fastcgi_params /tmp/koi-win /tmp/map_https_fcgi.conf /tmp/nginx.conf \
        /tmp/lua /tmp/sites-enabled /tmp/win-utf \
          /etc/nginx && \
     mv /tmp/run_nginx /etc/services.d/nginx/run && \

--- a/alpine-php/php-k8s-v8/etc/nginx/nginx.conf
+++ b/alpine-php/php-k8s-v8/etc/nginx/nginx.conf
@@ -23,7 +23,15 @@ env NGINX_SERVERNAME;
 ## Allow protocol redirect bypass.
 env NGINX_OVERRIDE_PROTOCOL;
 
-## Need LUA to determine the correct server_name.
+## A default rate limit and burst rate for bots.
+env NGINX_LIMIT_BOTS;
+env NGINX_BURST_BOTS;
+
+## A default rate limit and burst for humans.
+env NGINX_LIMIT_HUMANS;
+env NGINX_BURST_HUMANS;
+
+## Need LUA to determine the correct server_name and do rate limiting.
 load_module /var/lib/nginx/modules/ndk_http_module.so;
 load_module /var/lib/nginx/modules/ngx_http_lua_module.so;
 
@@ -85,7 +93,6 @@ http {
   ## Optimization of socket handling when using sendfile.
   tcp_nopush on;
 
-
   ## Compression.
   gzip on;
   gzip_buffers 16 8k;
@@ -142,6 +149,9 @@ http {
 
   ## Include blacklist for bad bot and referer blocking.
   include /etc/nginx/blacklist.conf;
+
+  ## Rate limiting. Limits are per remote IP address per backend.
+  include /etc/nginx/ratelimit.conf;
 
   ## Include the caching setup. Needed for using Drupal with an external cache.
   include apps/drupal/map_cache.conf;

--- a/alpine-php/php-k8s-v8/etc/nginx/nginx.conf
+++ b/alpine-php/php-k8s-v8/etc/nginx/nginx.conf
@@ -23,15 +23,7 @@ env NGINX_SERVERNAME;
 ## Allow protocol redirect bypass.
 env NGINX_OVERRIDE_PROTOCOL;
 
-## A default rate limit and burst rate for bots.
-env NGINX_LIMIT_BOTS;
-env NGINX_BURST_BOTS;
-
-## A default rate limit and burst for humans.
-env NGINX_LIMIT_HUMANS;
-env NGINX_BURST_HUMANS;
-
-## Need LUA to determine the correct server_name and do rate limiting.
+## Need LUA to determine the correct server_name.
 load_module /var/lib/nginx/modules/ndk_http_module.so;
 load_module /var/lib/nginx/modules/ngx_http_lua_module.so;
 

--- a/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf
+++ b/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf
@@ -3,8 +3,8 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default         0;
-        ~*(bot|crawler) 1;
+        default                0;
+        ~*(bot|crawler|spider) 1;
 }
 
 ## Set a limit zone based on the bot status.

--- a/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf
+++ b/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf
@@ -1,9 +1,3 @@
-## Grab the rate limit settings from the environment.
-set_by_lua $nginx_limit_bots 'return os.getenv("NGINX_LIMIT_BOTS")';
-set_by_lua $nginx_burst_bots 'return os.getenv("NGINX_BURST_BOTS")';
-set_by_lua $nginx_limit_humans 'return os.getenv("NGINX_LIMIT_HUMANS")';
-set_by_lua $nginx_burst_humans 'return os.getenv("NGINX_BURST_HUMANS")';
-
 ## A rate limit request returns status 429.
 limit_req_status 429;
 
@@ -20,9 +14,9 @@ map $isbot_ua $limit_bot {
 }
 
 ## Apply the rate limits.
-limit_req_zone $limit_bot zone=bots:10m rate=$nginx_limit_bots;
-limit_req_zone $binary_remote_addr zone=humans:10m rate=$nginx_limit_humans;
+limit_req_zone $limit_bot zone=bots:10m rate=2r/m;
+limit_req_zone $binary_remote_addr zone=humans:10m rate=16r/s;
 
 ## Apply the burst limits.
-limit_req zone=bots burst=$nginx_burst_bots nodelay;
-limit_req zone=humans burst=$nginx_burst_humans nodelay;
+limit_req zone=bots burst=2 nodelay;
+limit_req zone=humans burst=16 nodelay;

--- a/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf
+++ b/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf
@@ -1,0 +1,28 @@
+## Grab the rate limit settings from the environment.
+set_by_lua $nginx_limit_bots 'return os.getenv("NGINX_LIMIT_BOTS")';
+set_by_lua $nginx_burst_bots 'return os.getenv("NGINX_BURST_BOTS")';
+set_by_lua $nginx_limit_humans 'return os.getenv("NGINX_LIMIT_HUMANS")';
+set_by_lua $nginx_burst_humans 'return os.getenv("NGINX_BURST_HUMANS")';
+
+## A rate limit request returns status 429.
+limit_req_status 429;
+
+## Determine if this is a bot request via the user-agent string.
+map $http_user_agent $isbot_ua {
+        default         0;
+        ~*(bot|crawler) 1;
+}
+
+## Set a limit zone based on the bot status.
+map $isbot_ua $limit_bot {
+        0       "";
+        1       $binary_remote_addr;
+}
+
+## Apply the rate limits.
+limit_req_zone $limit_bot zone=bots:10m rate=$nginx_limit_bots;
+limit_req_zone $binary_remote_addr zone=humans:10m rate=$nginx_limit_humans;
+
+## Apply the burst limits.
+limit_req zone=bots burst=$nginx_burst_bots nodelay;
+limit_req zone=humans burst=$nginx_burst_humans nodelay;

--- a/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf.template
+++ b/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf.template
@@ -1,3 +1,5 @@
+## Apply settings from the environment at boot time via envsubst.
+
 ## A rate limit request returns status 429.
 limit_req_status 429;
 
@@ -14,9 +16,9 @@ map $isbot_ua $limit_bot {
 }
 
 ## Apply the rate limits.
-limit_req_zone $limit_bot zone=bots:10m rate=2r/m;
-limit_req_zone $binary_remote_addr zone=humans:10m rate=16r/s;
+limit_req_zone $limit_bot zone=bots:10m rate=${NGINX_LIMIT_BOTS};
+limit_req_zone $binary_remote_addr zone=humans:10m rate=${NGINX_LIMIT_HUMANS};
 
 ## Apply the burst limits.
-limit_req zone=bots burst=2 nodelay;
-limit_req zone=humans burst=16 nodelay;
+limit_req zone=bots burst=${NGINX_BURST_BOTS} nodelay;
+limit_req zone=humans burst=${NGINX_BURST_HUMANS} nodelay;

--- a/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf.template
+++ b/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf.template
@@ -5,8 +5,8 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default         0;
-        ~*(bot|crawler) 1;
+        default                0;
+        ~*(bot|crawler|spider) 1;
 }
 
 ## Set a limit zone based on the bot status.

--- a/alpine-php/php-k8s-v8/etc/services.d/run_nginx
+++ b/alpine-php/php-k8s-v8/etc/services.d/run_nginx
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv sh
 set -e
 
-exec nginx -g "daemon off;"
+envsubst '$NGINX_LIMIT_BOTS $NGINX_BURST_BOTS $NGINX_LIMIT_HUMANS $NGINX_BURST_HUMANS' < /etc/nginx/ratelimit.conf.template > /etc/nginx/ratelimit.conf && exec nginx -g "daemon off;"


### PR DESCRIPTION
No joy on the LUA, so add gettext and use envsubst to generate the config file at boot time.

The defaults are what FTS is currently using. 2 requests per minute per remote IP per web host for bots, 16 per second for actual people.