### PR TITLE
[OPS-7843] Move gettext to the base image and use envsubst to configure xdebug.

### DIFF
--- a/alpine-base-php/php7/Dockerfile.tmpl
+++ b/alpine-base-php/php7/Dockerfile.tmpl
@@ -74,6 +74,7 @@ RUN \
     apk -U upgrade && \
     apk add --update-cache \
       fcgi \
+      gettext \
       gnu-libiconv \
       imagemagick \
       msmtp \
@@ -141,7 +142,7 @@ RUN \
     # Configure php.
     rm -rf /etc/php7 && \
     mkdir -p /etc/php7 && \
-    mv -f /tmp/php.ini /tmp/conf.d /tmp/php-fpm.conf /tmp/php-fpm.d /tmp/environment.d /etc/php7 && \
+    mv -f /tmp/php.ini /tmp/conf.d /tmp/php-fpm.conf /tmp/php-fpm.d /tmp/environment.d /tmp/xdebug.template /etc/php7 && \
     \
     # Configure PHP logs.
     rm -rf /var/log/php7 && \

--- a/alpine-base-php/php7/etc/php7/xdebug.template
+++ b/alpine-base-php/php7/etc/php7/xdebug.template
@@ -1,0 +1,9 @@
+[xdebug]
+zend_extension=xdebug.so
+
+xdebug.remote_host         = ${PHP_XDEBUG_REMOTE_HOST}
+xdebug.remote_autostart    = ${PHP_XDEBUG_REMOTE_AUTOSTART}
+xdebug.remote_enable       = ${PHP_XDEBUG_REMOTE_ENABLE}
+xdebug.remote_port         = ${PHP_XDEBUG_REMOTE_PORT}
+xdebug.default_enable      = ${PHP_XDEBUG_DEFAULT_ENABLE}
+xdebug.remote_connect_back = ${PHP_XDEBUG_REMOTE_CONNECT_BACK}

--- a/alpine-base-php/php7/etc/services/run_fpm
+++ b/alpine-base-php/php7/etc/services/run_fpm
@@ -1,8 +1,15 @@
 #!/usr/bin/with-contenv sh
 set -e
 
+# If the PHP_XDEBUG env var is "true", and we are not in a production environment, then drop a config snippet to load the xdebug module before starting.
 if [ "${PHP_XDEBUG}" = "true" ]; then
-  exec /usr/sbin/php-fpm7 -c /etc/php7/php.ini -d zend_extension=xdebug.so -y /etc/php7/php-fpm.conf -F
-else
-  exec /usr/sbin/php-fpm7 -c /etc/php7/php.ini -y /etc/php7/php-fpm.conf -F
+  case "${PHP_ENVIRONMENT}" in
+    prod|production)
+      # No xdebug.
+      ;;
+    *)
+      envsubst '$PHP_XDEBUG_REMOTE_HOST $PHP_XDEBUG_REMOTE_AUTOSTART $PHP_XDEBUG_REMOTE_ENABLE $PHP_XDEBUG_REMOTE_PORT $PHP_XDEBUG_DEFAULT_ENABLE $PHP_XDEBUG_REMOTE_CONNECT_BACK' < /etc/php7/xdebug.template > /etc/php7/conf.d/90_xdebug.ini
+      ;;
+  esac
 fi
+exec /usr/sbin/php-fpm7 -c /etc/php7/php.ini -y /etc/php7/php-fpm.conf -F

--- a/alpine-base-php/php8/Dockerfile.tmpl
+++ b/alpine-base-php/php8/Dockerfile.tmpl
@@ -73,6 +73,7 @@ RUN \
     apk -U upgrade && \
     apk add --update-cache \
       fcgi \
+      gettext \
       gnu-libiconv \
       imagemagick \
       msmtp \
@@ -139,7 +140,7 @@ RUN \
     # Configure php.
     rm -rf /etc/php8 && \
     mkdir -p /etc/php8 && \
-    mv -f /tmp/php.ini /tmp/conf.d /tmp/php-fpm.conf /tmp/php-fpm.d /tmp/environment.d /etc/php8 && \
+    mv -f /tmp/php.ini /tmp/conf.d /tmp/php-fpm.conf /tmp/php-fpm.d /tmp/environment.d /tmp/xdebug.template /etc/php8 && \
     ln -sf /usr/bin/php8 /usr/bin/php && \
     \
     # Configure PHP logs.

--- a/alpine-base-php/php8/etc/php8/xdebug.template
+++ b/alpine-base-php/php8/etc/php8/xdebug.template
@@ -1,0 +1,9 @@
+[xdebug]
+zend_extension=xdebug.so
+
+xdebug.remote_host         = ${PHP_XDEBUG_REMOTE_HOST}
+xdebug.remote_autostart    = ${PHP_XDEBUG_REMOTE_AUTOSTART}
+xdebug.remote_enable       = ${PHP_XDEBUG_REMOTE_ENABLE}
+xdebug.remote_port         = ${PHP_XDEBUG_REMOTE_PORT}
+xdebug.default_enable      = ${PHP_XDEBUG_DEFAULT_ENABLE}
+xdebug.remote_connect_back = ${PHP_XDEBUG_REMOTE_CONNECT_BACK}

--- a/alpine-base-php/php8/etc/services/run_fpm
+++ b/alpine-base-php/php8/etc/services/run_fpm
@@ -1,8 +1,15 @@
 #!/usr/bin/with-contenv sh
 set -e
 
+# If the PHP_XDEBUG env var is "true", then drop a config snippet to load the xdebug module before starting.
 if [ "${PHP_XDEBUG}" = "true" ]; then
-  exec /usr/sbin/php-fpm8 -c /etc/php8/php.ini -d zend_extension=xdebug.so -y /etc/php8/php-fpm.conf -F
-else
-  exec /usr/sbin/php-fpm8 -c /etc/php8/php.ini -y /etc/php8/php-fpm.conf -F
+  case "${PHP_ENVIRONMENT}" in
+    prod|production)
+      # No xdebug.
+      ;;
+    *)
+      envsubst '$PHP_XDEBUG_REMOTE_HOST $PHP_XDEBUG_REMOTE_AUTOSTART $PHP_XDEBUG_REMOTE_ENABLE $PHP_XDEBUG_REMOTE_PORT $PHP_XDEBUG_DEFAULT_ENABLE $PHP_XDEBUG_REMOTE_CONNECT_BACK' < /etc/php8/xdebug.template > /etc/php8/conf.d/90_xdebug.ini
+      ;;
+  esac
 fi
+exec /usr/sbin/php-fpm8 -c /etc/php8/php.ini -y /etc/php8/php-fpm.conf -F

--- a/alpine-php/php-k8s-v7/Dockerfile.tmpl
+++ b/alpine-php/php-k8s-v7/Dockerfile.tmpl
@@ -41,7 +41,7 @@ COPY etc/drush/drushrc.php \
 
 # Install NGINX for standard operation.
 RUN \
-    apk add -U gettext nginx nginx-mod-http-upload-progress nginx-mod-http-lua && \
+    apk add -U nginx nginx-mod-http-upload-progress nginx-mod-http-lua && \
     mkdir -p /etc/services.d/nginx && \
     rm -rf /etc/nginx/* && \
     mv /tmp/apps /tmp/fastcgi.conf /tmp/koi-utf /tmp/map_block_http_methods.conf /tmp/mime.types /tmp/upstream_phpcgi_unix.conf \

--- a/alpine-php/php-k8s-v8/Dockerfile.tmpl
+++ b/alpine-php/php-k8s-v8/Dockerfile.tmpl
@@ -38,7 +38,7 @@ COPY etc/nginx/ etc/services.d/run_nginx \
 
 # Install NGINX for standard operation.
 RUN \
-    apk add -U gettext nginx nginx-mod-http-upload-progress nginx-mod-http-lua && \
+    apk add -U nginx nginx-mod-http-upload-progress nginx-mod-http-lua && \
     mkdir -p /etc/services.d/nginx && \
     rm -rf /etc/nginx/* && \
     mv /tmp/apps /tmp/fastcgi.conf /tmp/koi-utf /tmp/map_block_http_methods.conf /tmp/mime.types /tmp/upstream_phpcgi_unix.conf \


### PR DESCRIPTION
* Generate an ini snippet at startup, so it will work for CLI as well as FPM.
* Enable xdebug if an envvar is "true" *and* the environment name is not production.
* Needs gettext, so move that out of the k8s image and into base.