### PR TITLE
[OPS-7949] Use alpine s6-overlay package

### DIFF
--- a/alpine-base-s6/Dockerfile.tmpl
+++ b/alpine-base-s6/Dockerfile.tmpl
@@ -23,9 +23,7 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.distribution-version=$UPSTREAM \
       org.label-schema.s6-version=$S6_VERSION
 
-RUN curl -sL https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz -o /tmp/s6.tgz && \
-    tar xzf /tmp/s6.tgz -C / && \
-    rm -f /tmp/s6.tgz
+RUN apk add s6-overlay
 
 ENTRYPOINT ["/init"]
 

--- a/nodejs/base/Dockerfile.tmpl
+++ b/nodejs/base/Dockerfile.tmpl
@@ -51,7 +51,8 @@ RUN set +x && apk update && \
    apk add --no-cache \
         shadow \
         curl \
-        git && \
+        git \
+        s6-overlay && \
    yarn global add \
         grunt-cli \
         newrelic && \
@@ -67,9 +68,6 @@ RUN set +x && apk update && \
     chmod 1777 /tmp && \
     mkdir -p ${SRC_DIR} ${NODE_APP_DIR} && \
     cp -a /usr/local/share/.config/yarn/global/node_modules/newrelic/newrelic.js /srv && \
-    curl -sL https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz -o /tmp/s6.tgz && \
-    tar xzf /tmp/s6.tgz -C / && \
-    rm -f /tmp/s6.tgz && \
     groupadd --system -g $APPUSER_GID appuser && \
     useradd --system -u $APPUSER_UID -s /sbin/nologin -c 'Docker App User' \
       -d /home/appuser -g appuser -m appuser

--- a/postgis/Dockerfile.tmpl
+++ b/postgis/Dockerfile.tmpl
@@ -40,13 +40,11 @@ RUN apk update && \
     apk upgrade && \
     apk add \
         curl \
+        s6-overlay \
         nano \
         postgresql \
         postgresql-client \
         postgresql-contrib && \
-    curl -sL https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz -o /tmp/s6.tgz && \
-    tar xzf /tmp/s6.tgz -C / && \
-    rm -f /tmp/s6.tgz && \
     mkdir -p /etc/services.d/postgres /etc/fix-attrs.d /etc/pgsql /run/postgresql && \
     mv /tmp/fix_pgsql_dirs /etc/fix-attrs.d/ && \
     mv /tmp/run_postgres /etc/services.d/postgres/run && \


### PR DESCRIPTION
Ticket: OPS-7949

Use the alpine s6-overlay package instead of downloading the amd64 release so that the alpine-base-s6 and all the other images based on it can run on other architectures like arm64.