### PR TITLE
[OPS-8055] Treat pingdom as a human, so there are no fake outage alerts due to bot rate limiting.

### DIFF
--- a/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf
+++ b/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf
@@ -4,6 +4,7 @@ limit_req_status 429;
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
         default                0;
+        ~*pingdom              0;
         ~*(bot|crawler|spider) 1;
 }
 

--- a/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf.template
+++ b/alpine-php/php-k8s-v7/etc/nginx/ratelimit.conf.template
@@ -6,6 +6,7 @@ limit_req_status 429;
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
         default                0;
+        ~*pingdom              0;
         ~*(bot|crawler|spider) 1;
 }
 

--- a/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf
+++ b/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf
@@ -4,6 +4,7 @@ limit_req_status 429;
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
         default                0;
+        ~*pingdom              0;
         ~*(bot|crawler|spider) 1;
 }
 

--- a/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf.template
+++ b/alpine-php/php-k8s-v8/etc/nginx/ratelimit.conf.template
@@ -6,6 +6,7 @@ limit_req_status 429;
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
         default                0;
+        ~*pingdom              0;
         ~*(bot|crawler|spider) 1;
 }
 


### PR DESCRIPTION
The nginx docs at http://nginx.org/en/docs/http/ngx_http_map_module.html say the first match is used, so this should do the trick. The Pingdom UA is `Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)`.

This will avoid the spurious outage alerts for RW after a new build + deploy.