### PR TITLE
feat: Default to blocking the beaglesecurity user-agent, as it leaks …

### DIFF
--- a/php/php-k8s-v7/etc/nginx/blocklist.conf
+++ b/php/php-k8s-v7/etc/nginx/blocklist.conf
@@ -17,6 +17,7 @@ map $http_user_agent $bad_bot {
     ~fantastic_search_engine_crawler 1;
     ~Jooblebot                       1;
     ~PetalBot                        1; # See OPS-7987.
+    ~*Beagle                         1; # See OPS-8727.
 }
 
 ## Add here all referrers that are to blocked.

--- a/php/php-k8s-v8/etc/nginx/blocklist.conf
+++ b/php/php-k8s-v8/etc/nginx/blocklist.conf
@@ -17,6 +17,7 @@ map $http_user_agent $bad_bot {
     ~fantastic_search_engine_crawler 1;
     ~Jooblebot                       1;
     ~PetalBot                        1; # See OPS-7987.
+    ~*Beagle                         1; # See OPS-8727.
 }
 
 ## Add here all referrers that are to blocked.

--- a/php/php-k8s-v81/etc/nginx/blocklist.conf
+++ b/php/php-k8s-v81/etc/nginx/blocklist.conf
@@ -17,6 +17,7 @@ map $http_user_agent $bad_bot {
     ~fantastic_search_engine_crawler 1;
     ~Jooblebot                       1;
     ~PetalBot                        1; # See OPS-7987.
+    ~*Beagle                         1; # See OPS-8727.
 }
 
 ## Add here all referrers that are to blocked.


### PR DESCRIPTION
…across hostnames to the apex domain.

The actual string used is "Mozilla/5.0 (Windows NT 10.0; WOW64) / beagle" so we need to be not case sensitive. This rule can be disabled prior to a scheduled scan for a given property.

Refs: OPS-8727