### PR TITLE
fix: Add HSTS and RP headers to the base image, since we no longer use seckit.

### DIFF
--- a/php/php-k8s-v7/etc/nginx/nginx.conf
+++ b/php/php-k8s-v7/etc/nginx/nginx.conf
@@ -62,9 +62,6 @@ http {
   # Enable RealIP recursion.
   real_ip_recursive on;
 
-  # Remove the Server header.
-  more_clear_headers Server;
-
   types_hash_max_size 1024;
   types_hash_bucket_size 512;
 
@@ -110,6 +107,9 @@ http {
   ## We use the docker one, which points at the AWS one, so we get internal resolution.
   resolver 127.0.0.11 ipv6=off;
 
+  # Remove the Server header.
+  more_clear_headers Server;
+
   ## Enable the builtin cross-site scripting (XSS) filter available
   ## in modern browsers.  Usually enabled by default we just
   ## reinstate in case it has been somehow disabled for this
@@ -118,17 +118,33 @@ http {
   map $upstream_http_x_xss_protection $xssprotection {
       default   $upstream_http_x_xss_protection;
       ""        "1; mode=block";
-   }
+  }
+  more_clear_headers "X-XSS-Protection";
   add_header X-XSS-Protection $xssprotection;
 
   ## Block MIME type sniffing on IE.
-  add_header X-Content-Options nosniff;
+  map $upstream_http_x_content_options $contentoptions {
+      default   $upstream_http_x_content_options;
+      ""        "nosniff";
+  }
+  more_clear_headers "X-Content-Options";
+  add_header X-Content-Options $contentoptions;
 
   ## Enable HSTS.
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload; always;";
+  map $upstream_http_strict_transport_security $stricttransportsecurity {
+      default   $upstream_http_strict_transport_security;
+      ""        "max-age=31536000; includeSubDomains; preload; always;";
+  }
+  more_clear_headers "Strict-Transport-Security";
+  add_header Strict-Transport-Security $stricttransportsecurity;
 
   ## Enable Referer-Policy.
-  add_header Referrer-Policy "strict-origin-when-cross-origin";
+    map $upstream_http_referer_policy $refererpolicy {
+      default   $upstream_http_strict_transport_security;
+      ""        "strict-origin-when-cross-origin";
+  }
+  more_clear_headers "Referrer-Policy";
+  add_header Referrer-Policy $refererpolicy;
 
   ## FastCGI.
   include /etc/nginx/fastcgi.conf;

--- a/php/php-k8s-v7/etc/nginx/nginx.conf
+++ b/php/php-k8s-v7/etc/nginx/nginx.conf
@@ -125,7 +125,7 @@ http {
   add_header X-Content-Options nosniff;
 
   ## Enable HSTS.
-  add_header Strict-tRansport-Security "max-age=31536000; includeSubDomains; preload; always;";
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload; always;";
 
   ## Enable Referer-Policy.
   add_header Referrer-Policy "strict-origin-when-cross-origin";

--- a/php/php-k8s-v7/etc/nginx/nginx.conf
+++ b/php/php-k8s-v7/etc/nginx/nginx.conf
@@ -119,10 +119,16 @@ http {
       default   $upstream_http_x_xss_protection;
       ""        "1; mode=block";
    }
-   add_header X-XSS-Protection $xssprotection;
+  add_header X-XSS-Protection $xssprotection;
 
   ## Block MIME type sniffing on IE.
   add_header X-Content-Options nosniff;
+
+  ## Enable HSTS.
+  add_header Strict-tRansport-Security "max-age=31536000; includeSubDomains; preload; always;";
+
+  ## Enable Referer-Policy.
+  add_header Referrer-Policy "strict-origin-when-cross-origin";
 
   ## FastCGI.
   include /etc/nginx/fastcgi.conf;

--- a/php/php-k8s-v8/etc/nginx/nginx.conf
+++ b/php/php-k8s-v8/etc/nginx/nginx.conf
@@ -126,7 +126,7 @@ http {
   add_header X-Content-Options nosniff;
 
   ## Enable HSTS.
-  add_header Strict-tRansport-Security "max-age=31536000; includeSubDomains; preload; always;";
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload; always;";
 
   ## Enable Referer-Policy.
   add_header Referrer-Policy "strict-origin-when-cross-origin";

--- a/php/php-k8s-v8/etc/nginx/nginx.conf
+++ b/php/php-k8s-v8/etc/nginx/nginx.conf
@@ -125,6 +125,12 @@ http {
   ## Block MIME type sniffing on IE.
   add_header X-Content-Options nosniff;
 
+  ## Enable HSTS.
+  add_header Strict-tRansport-Security "max-age=31536000; includeSubDomains; preload; always;";
+
+  ## Enable Referer-Policy.
+  add_header Referrer-Policy "strict-origin-when-cross-origin";
+
   ## FastCGI.
   include /etc/nginx/fastcgi.conf;
 

--- a/php/php-k8s-v8/etc/nginx/nginx.conf
+++ b/php/php-k8s-v8/etc/nginx/nginx.conf
@@ -63,9 +63,6 @@ http {
   # Enable RealIP recursion.
   real_ip_recursive on;
 
-  # Remove the Server header.
-  more_clear_headers Server;
-
   types_hash_max_size 1024;
   types_hash_bucket_size 512;
 
@@ -111,6 +108,9 @@ http {
   ## We use the docker one, which points at the AWS one, so we get internal resolution.
   resolver 127.0.0.11 ipv6=off;
 
+  # Remove the Server header.
+  more_clear_headers Server;
+
   ## Enable the builtin cross-site scripting (XSS) filter available
   ## in modern browsers.  Usually enabled by default we just
   ## reinstate in case it has been somehow disabled for this
@@ -119,17 +119,33 @@ http {
   map $upstream_http_x_xss_protection $xssprotection {
       default   $upstream_http_x_xss_protection;
       ""        "1; mode=block";
-   }
-   add_header X-XSS-Protection $xssprotection;
+  }
+  more_clear_headers "X-XSS-Protection";
+  add_header X-XSS-Protection $xssprotection;
 
   ## Block MIME type sniffing on IE.
-  add_header X-Content-Options nosniff;
+  map $upstream_http_x_content_options $contentoptions {
+      default   $upstream_http_x_content_options;
+      ""        "nosniff";
+  }
+  more_clear_headers "X-Content-Options";
+  add_header X-Content-Options $contentoptions;
 
   ## Enable HSTS.
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload; always;";
+  map $upstream_http_strict_transport_security $stricttransportsecurity {
+      default   $upstream_http_strict_transport_security;
+      ""        "max-age=31536000; includeSubDomains; preload; always;";
+  }
+  more_clear_headers "Strict-Transport-Security";
+  add_header Strict-Transport-Security $stricttransportsecurity;
 
   ## Enable Referer-Policy.
-  add_header Referrer-Policy "strict-origin-when-cross-origin";
+    map $upstream_http_referer_policy $refererpolicy {
+      default   $upstream_http_strict_transport_security;
+      ""        "strict-origin-when-cross-origin";
+  }
+  more_clear_headers "Referrer-Policy";
+  add_header Referrer-Policy $refererpolicy;
 
   ## FastCGI.
   include /etc/nginx/fastcgi.conf;

--- a/php/php-k8s-v81/etc/nginx/nginx.conf
+++ b/php/php-k8s-v81/etc/nginx/nginx.conf
@@ -124,6 +124,12 @@ http {
   ## Block MIME type sniffing on IE.
   add_header X-Content-Options nosniff;
 
+  ## Enable HSTS.
+  add_header Strict-tRansport-Security "max-age=31536000; includeSubDomains; preload; always;";
+
+  ## Enable Referer-Policy.
+  add_header Referrer-Policy "strict-origin-when-cross-origin";
+
   ## FastCGI.
   include /etc/nginx/fastcgi.conf;
 

--- a/php/php-k8s-v81/etc/nginx/nginx.conf
+++ b/php/php-k8s-v81/etc/nginx/nginx.conf
@@ -125,7 +125,7 @@ http {
   add_header X-Content-Options nosniff;
 
   ## Enable HSTS.
-  add_header Strict-tRansport-Security "max-age=31536000; includeSubDomains; preload; always;";
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload; always;";
 
   ## Enable Referer-Policy.
   add_header Referrer-Policy "strict-origin-when-cross-origin";

--- a/php/php-k8s-v81/etc/nginx/nginx.conf
+++ b/php/php-k8s-v81/etc/nginx/nginx.conf
@@ -62,9 +62,6 @@ http {
   # Enable RealIP recursion.
   real_ip_recursive on;
 
-  # Remove the Server header.
-  more_clear_headers Server;
-
   types_hash_max_size 1024;
   types_hash_bucket_size 512;
 
@@ -110,6 +107,9 @@ http {
   ## We use the docker one, which points at the AWS one, so we get internal resolution.
   resolver 127.0.0.11 ipv6=off;
 
+  # Remove the Server header.
+  more_clear_headers Server;
+
   ## Enable the builtin cross-site scripting (XSS) filter available
   ## in modern browsers.  Usually enabled by default we just
   ## reinstate in case it has been somehow disabled for this
@@ -118,17 +118,33 @@ http {
   map $upstream_http_x_xss_protection $xssprotection {
       default   $upstream_http_x_xss_protection;
       ""        "1; mode=block";
-   }
-   add_header X-XSS-Protection $xssprotection;
+  }
+  more_clear_headers "X-XSS-Protection";
+  add_header X-XSS-Protection $xssprotection;
 
   ## Block MIME type sniffing on IE.
-  add_header X-Content-Options nosniff;
+  map $upstream_http_x_content_options $contentoptions {
+      default   $upstream_http_x_content_options;
+      ""        "nosniff";
+  }
+  more_clear_headers "X-Content-Options";
+  add_header X-Content-Options $contentoptions;
 
   ## Enable HSTS.
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload; always;";
+  map $upstream_http_strict_transport_security $stricttransportsecurity {
+      default   $upstream_http_strict_transport_security;
+      ""        "max-age=31536000; includeSubDomains; preload; always;";
+  }
+  more_clear_headers "Strict-Transport-Security";
+  add_header Strict-Transport-Security $stricttransportsecurity;
 
   ## Enable Referer-Policy.
-  add_header Referrer-Policy "strict-origin-when-cross-origin";
+    map $upstream_http_referer_policy $refererpolicy {
+      default   $upstream_http_strict_transport_security;
+      ""        "strict-origin-when-cross-origin";
+  }
+  more_clear_headers "Referrer-Policy";
+  add_header Referrer-Policy $refererpolicy;
 
   ## FastCGI.
   include /etc/nginx/fastcgi.conf;


### PR DESCRIPTION
This will make Beaglesecurity happier.

Refs: OPS-8746