### PR TITLE
feat: Set a default X-Frame-Options header if the app does not provide one.

### DIFF
--- a/php/php-k8s-v8/etc/nginx/nginx.conf
+++ b/php/php-k8s-v8/etc/nginx/nginx.conf
@@ -131,6 +131,14 @@ http {
   more_clear_headers "X-Content-Options";
   add_header X-Content-Options $contentoptions;
 
+  ## Set default frame options.
+  map $upstream_http_x_frame_options $frameoptions {
+      default   $upstream_http_x_frame_options;
+      ""        "SAMEORIGIN";
+  }
+  more_clear_headers "X-Frame-Options";
+  add_header X-Frame-Options $frameoptions;
+
   ## Enable HSTS.
   map $upstream_http_strict_transport_security $stricttransportsecurity {
       default   $upstream_http_strict_transport_security;
@@ -140,7 +148,7 @@ http {
   add_header Strict-Transport-Security $stricttransportsecurity;
 
   ## Enable Referer-Policy.
-    map $upstream_http_referer_policy $refererpolicy {
+  map $upstream_http_referer_policy $refererpolicy {
       default   $upstream_http_strict_transport_security;
       ""        "strict-origin-when-cross-origin";
   }

--- a/php/php-k8s-v81/etc/nginx/nginx.conf
+++ b/php/php-k8s-v81/etc/nginx/nginx.conf
@@ -130,6 +130,14 @@ http {
   more_clear_headers "X-Content-Options";
   add_header X-Content-Options $contentoptions;
 
+  ## Set default frame options.
+  map $upstream_http_x_frame_options $frameoptions {
+      default   $upstream_http_x_frame_options;
+      ""        "SAMEORIGIN";
+  }
+  more_clear_headers "X-Frame-Options";
+  add_header X-Frame-Options $frameoptions;
+
   ## Enable HSTS.
   map $upstream_http_strict_transport_security $stricttransportsecurity {
       default   $upstream_http_strict_transport_security;
@@ -139,7 +147,7 @@ http {
   add_header Strict-Transport-Security $stricttransportsecurity;
 
   ## Enable Referer-Policy.
-    map $upstream_http_referer_policy $refererpolicy {
+  map $upstream_http_referer_policy $refererpolicy {
       default   $upstream_http_strict_transport_security;
       ""        "strict-origin-when-cross-origin";
   }

--- a/php/php-k8s-v82/etc/nginx/nginx.conf
+++ b/php/php-k8s-v82/etc/nginx/nginx.conf
@@ -122,6 +122,14 @@ http {
   more_clear_headers "X-XSS-Protection";
   add_header X-XSS-Protection $xssprotection;
 
+  ## Set default frame options.
+  map $upstream_http_x_frame_options $frameoptions {
+      default   $upstream_http_x_frame_options;
+      ""        "SAMEORIGIN";
+  }
+  more_clear_headers "X-Frame-Options";
+  add_header X-Frame-Options $frameoptions;
+
   ## Block MIME type sniffing on IE.
   map $upstream_http_x_content_options $contentoptions {
       default   $upstream_http_x_content_options;
@@ -139,7 +147,7 @@ http {
   add_header Strict-Transport-Security $stricttransportsecurity;
 
   ## Enable Referer-Policy.
-    map $upstream_http_referer_policy $refererpolicy {
+  map $upstream_http_referer_policy $refererpolicy {
       default   $upstream_http_strict_transport_security;
       ""        "strict-origin-when-cross-origin";
   }


### PR DESCRIPTION
This should make Beagle Security happier with most sites, but specifically with RW API.

Refs: OPS-8936