### PR TITLE
feat: Drop in the Drupal 8+ fastcgi config as default.

### DIFF
--- a/php/php-k8s-v8/etc/nginx/apps/drupal/fastcgi_drupal.conf
+++ b/php/php-k8s-v8/etc/nginx/apps/drupal/fastcgi_drupal.conf
@@ -1,7 +1,7 @@
 #-*- mode: nginx; mode: flyspell-prog; ispell-local-dictionary: "american" -*-
 ### fastcgi configuration for serving private files.
 ## 1. Parameters.
-fastcgi_param QUERY_STRING q=$uri&$args;
+fastcgi_param QUERY_STRING $args;
 fastcgi_param REQUEST_METHOD $request_method;
 fastcgi_param CONTENT_TYPE $content_type;
 fastcgi_param CONTENT_LENGTH $content_length;
@@ -37,7 +37,8 @@ fastcgi_intercept_errors on;
 ## Allow 4 hrs - pass timeout responsibility to upstream.
 fastcgi_read_timeout 14400;
 fastcgi_index index.php;
-## Hide the X-Drupal-Cache header provided by Pressflow.
+## Hide the Drupal cache headers.
 fastcgi_hide_header 'X-Drupal-Cache';
-## Hide the Drupal 7 header X-Generator.
+fastcgi_hide_header 'X-Drupal-Dynamic-Cache';
+## Hide the Drupal header X-Generator.
 fastcgi_hide_header 'X-Generator';

--- a/php/php-k8s-v81/etc/nginx/apps/drupal/fastcgi_drupal.conf
+++ b/php/php-k8s-v81/etc/nginx/apps/drupal/fastcgi_drupal.conf
@@ -1,7 +1,7 @@
 #-*- mode: nginx; mode: flyspell-prog; ispell-local-dictionary: "american" -*-
 ### fastcgi configuration for serving private files.
 ## 1. Parameters.
-fastcgi_param QUERY_STRING q=$uri&$args;
+fastcgi_param QUERY_STRING $args;
 fastcgi_param REQUEST_METHOD $request_method;
 fastcgi_param CONTENT_TYPE $content_type;
 fastcgi_param CONTENT_LENGTH $content_length;
@@ -37,7 +37,8 @@ fastcgi_intercept_errors on;
 ## Allow 4 hrs - pass timeout responsibility to upstream.
 fastcgi_read_timeout 14400;
 fastcgi_index index.php;
-## Hide the X-Drupal-Cache header provided by Pressflow.
+## Hide the Drupal cache headers.
 fastcgi_hide_header 'X-Drupal-Cache';
-## Hide the Drupal 7 header X-Generator.
+fastcgi_hide_header 'X-Drupal-Dynamic-Cache';
+## Hide the Drupal header X-Generator.
 fastcgi_hide_header 'X-Generator';

--- a/php/php-k8s-v82/etc/nginx/apps/drupal/fastcgi_drupal.conf
+++ b/php/php-k8s-v82/etc/nginx/apps/drupal/fastcgi_drupal.conf
@@ -1,7 +1,7 @@
 #-*- mode: nginx; mode: flyspell-prog; ispell-local-dictionary: "american" -*-
 ### fastcgi configuration for serving private files.
 ## 1. Parameters.
-fastcgi_param QUERY_STRING q=$uri&$args;
+fastcgi_param QUERY_STRING $args;
 fastcgi_param REQUEST_METHOD $request_method;
 fastcgi_param CONTENT_TYPE $content_type;
 fastcgi_param CONTENT_LENGTH $content_length;
@@ -37,7 +37,8 @@ fastcgi_intercept_errors on;
 ## Allow 4 hrs - pass timeout responsibility to upstream.
 fastcgi_read_timeout 14400;
 fastcgi_index index.php;
-## Hide the X-Drupal-Cache header provided by Pressflow.
+## Hide the Drupal cache headers.
 fastcgi_hide_header 'X-Drupal-Cache';
-## Hide the Drupal 7 header X-Generator.
+fastcgi_hide_header 'X-Drupal-Dynamic-Cache';
+## Hide the Drupal header X-Generator.
 fastcgi_hide_header 'X-Generator';


### PR DESCRIPTION
This now requires Drupal 7 sites to provide an override.

* https://github.com/UN-OCHA/unocha-org/pull/1256
* https://github.com/UN-OCHA/hrinfo-site/pull/1211

The non-Drupal PHP sites all already have a custom line that sets `fastcgi_param QUERY_STRING $query_string;` so they *should* not be affected either way.

Refs: OPS-8977