### PR TITLE
get rid of new relic on our nodejs images

### DIFF
--- a/nodejs/base/Dockerfile.tmpl
+++ b/nodejs/base/Dockerfile.tmpl
@@ -16,11 +16,6 @@ ENV NODE_VERSION=$NODE_VERSION \
     NODE_APP_DIR=/srv/www \
     NODE_PATH=/usr/lib/node_modules:/usr/local/lib/node_modules:/usr/local/share/.config/yarn/global/node_modules \
     SRC_DIR=/src \
-    NEW_RELIC_HOME=/srv/ \
-    NEW_RELIC_LOG_LEVEL=info \
-    NEW_RELIC_LICENSE_KEY=aaa \
-    NEW_RELIC_APP_NAME=nodeapp \
-    NEW_RELIC_NO_CONFIG_FILE=True \
     APPUSER_GID=4000 \
     APPUSER_UID=4000
 
@@ -53,8 +48,7 @@ RUN set +x && apk update && \
         curl \
         git && \
    yarn global add \
-        grunt-cli \
-        newrelic && \
+        grunt-cli && \
    yarn cache clean && \
    rm -rf \
         /usr/lib/node_modules/npm/man \

--- a/nodejs/debian-base/Dockerfile.tmpl
+++ b/nodejs/debian-base/Dockerfile.tmpl
@@ -52,8 +52,7 @@ RUN set -x && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /src/*.deb && \
     yarn global add \
-      grunt-cli \
-      newrelic && \
+      grunt-cli && \
     mkdir -p /tmp && \
     chmod 1777 /tmp && \
     mkdir -p ${SRC_DIR} ${NODE_APP_DIR} && \


### PR DESCRIPTION
!!! breaking change for apps still importing newrelic module !!!
do not merge until _all_ node apps stop using new relic.
