### PR TITLE
fix: Do not break UniteID logins in the standard image.

### DIFF
--- a/php/base/php81/Dockerfile.tmpl
+++ b/php/base/php81/Dockerfile.tmpl
@@ -47,7 +47,7 @@ ENV PS1="\u@\h:\w\n\$ " \
     PHP_MAX_INPUT_VARS=1000 \
     # Override PHP session cookie vars.
     PHP_SESSION_COOKIE_HTTPONLY=1 \
-    PHP_SESSION_COOKIE_SAMESITE=Strict \
+    PHP_SESSION_COOKIE_SAMESITE=Lax \
     # Allow developers to disable apc.
     PHP_APC_ENABLE=1 \
     PHP_APC_ENABLE_CLI=0 \

--- a/php/base/php82/Dockerfile.tmpl
+++ b/php/base/php82/Dockerfile.tmpl
@@ -47,7 +47,7 @@ ENV PS1="\u@\h:\w\n\$ " \
     PHP_MAX_INPUT_VARS=1000 \
     # Override PHP session cookie vars.
     PHP_SESSION_COOKIE_HTTPONLY=1 \
-    PHP_SESSION_COOKIE_SAMESITE=Strict \
+    PHP_SESSION_COOKIE_SAMESITE=Lax \
     # Allow developers to disable apc.
     PHP_APC_ENABLE=1 \
     PHP_APC_ENABLE_CLI=0 \

--- a/php/base/php83/Dockerfile.tmpl
+++ b/php/base/php83/Dockerfile.tmpl
@@ -47,7 +47,7 @@ ENV PS1="\u@\h:\w\n\$ " \
     PHP_MAX_INPUT_VARS=1000 \
     # Override PHP session cookie vars.
     PHP_SESSION_COOKIE_HTTPONLY=1 \
-    PHP_SESSION_COOKIE_SAMESITE=Strict \
+    PHP_SESSION_COOKIE_SAMESITE=Lax \
     # Allow developers to disable apc.
     PHP_APC_ENABLE=1 \
     PHP_APC_ENABLE_CLI=0 \

--- a/php/php-k8s-v8/Dockerfile.tmpl
+++ b/php/php-k8s-v8/Dockerfile.tmpl
@@ -12,10 +12,10 @@ ARG VCS_REF
 ARG BUILD_DATE
 
 ENV NGINX_SERVERNAME=localhost \
-    NGINX_LIMIT_BOTS=2r/m \
-    NGINX_BURST_BOTS=4 nodelay \
-    NGINX_LIMIT_HUMANS=16r/s \
-    NGINX_BURST_HUMANS=32 nodelay \
+    NGINX_LIMIT_BOTS="2r/m" \
+    NGINX_BURST_BOTS="4 nodelay" \
+    NGINX_LIMIT_HUMANS="16r/s" \
+    NGINX_BURST_HUMANS="32 nodelay" \
     PAGER=more \
     PATH=/srv/www/vendor/bin:$PATH \
     LD_PRELOAD=/usr/lib/preloadable_libiconv.so \

--- a/php/php-k8s-v81/Dockerfile.tmpl
+++ b/php/php-k8s-v81/Dockerfile.tmpl
@@ -12,10 +12,10 @@ ARG VCS_REF
 ARG BUILD_DATE
 
 ENV NGINX_SERVERNAME=localhost \
-    NGINX_LIMIT_BOTS=2r/m \
-    NGINX_BURST_BOTS=4 nodelay \
-    NGINX_LIMIT_HUMANS=16r/s \
-    NGINX_BURST_HUMANS=32 nodelay \
+    NGINX_LIMIT_BOTS="2r/m" \
+    NGINX_BURST_BOTS="4 nodelay" \
+    NGINX_LIMIT_HUMANS="16r/s" \
+    NGINX_BURST_HUMANS="32 nodelay" \
     PAGER=more \
     PATH=/srv/www/vendor/bin:$PATH \
     LD_PRELOAD=/usr/lib/preloadable_libiconv.so \

--- a/php/php-k8s-v82/Dockerfile.tmpl
+++ b/php/php-k8s-v82/Dockerfile.tmpl
@@ -12,10 +12,10 @@ ARG VCS_REF
 ARG BUILD_DATE
 
 ENV NGINX_SERVERNAME=localhost \
-    NGINX_LIMIT_BOTS=2r/m \
-    NGINX_BURST_BOTS=4 nodelay \
-    NGINX_LIMIT_HUMANS=16r/s \
-    NGINX_BURST_HUMANS=32 nodelay \
+    NGINX_LIMIT_BOTS="2r/m" \
+    NGINX_BURST_BOTS="4 nodelay" \
+    NGINX_LIMIT_HUMANS="16r/s" \
+    NGINX_BURST_HUMANS="32 nodelay" \
     PAGER=more \
     PATH=/srv/www/vendor/bin:$PATH \
     LD_PRELOAD=/usr/lib/preloadable_libiconv.so \

--- a/php/php-k8s-v83/Dockerfile.tmpl
+++ b/php/php-k8s-v83/Dockerfile.tmpl
@@ -12,10 +12,10 @@ ARG VCS_REF
 ARG BUILD_DATE
 
 ENV NGINX_SERVERNAME=localhost \
-    NGINX_LIMIT_BOTS=2r/m \
-    NGINX_BURST_BOTS=4 nodelay \
-    NGINX_LIMIT_HUMANS=16r/s \
-    NGINX_BURST_HUMANS=32 nodelay \
+    NGINX_LIMIT_BOTS="2r/m" \
+    NGINX_BURST_BOTS="4 nodelay" \
+    NGINX_LIMIT_HUMANS="16r/s" \
+    NGINX_BURST_HUMANS="32 nodelay" \
     PAGER=more \
     PATH=/srv/www/vendor/bin:$PATH \
     LD_PRELOAD=/usr/lib/preloadable_libiconv.so \


### PR DESCRIPTION
So default session.cookie_samesite to "Lax" instead of "Strict". Both make Drupal stop complaining.

And quote the rate limiting defaults, as the current docker versions needfs to break builds now if I don't do that.

Refs: OPS-9726