### PR TITLE
feat: En sure envs named `demo` use the production error display settings.

### DIFF
--- a/php/base/php8/etc/php8/environment.d/demo.conf
+++ b/php/base/php8/etc/php8/environment.d/demo.conf
@@ -1,0 +1,1 @@
+production.conf

--- a/php/base/php8/etc/php8/environment.d/demonstration.conf
+++ b/php/base/php8/etc/php8/environment.d/demonstration.conf
@@ -1,0 +1,1 @@
+production.conf

--- a/php/base/php81/etc/php81/environment.d/demo.conf
+++ b/php/base/php81/etc/php81/environment.d/demo.conf
@@ -1,0 +1,1 @@
+production.conf

--- a/php/base/php81/etc/php81/environment.d/demonstration.conf
+++ b/php/base/php81/etc/php81/environment.d/demonstration.conf
@@ -1,0 +1,1 @@
+production.conf

--- a/php/base/php82/etc/php82/environment.d/demo.conf
+++ b/php/base/php82/etc/php82/environment.d/demo.conf
@@ -1,0 +1,1 @@
+production.conf

--- a/php/base/php82/etc/php82/environment.d/demonstration.conf
+++ b/php/base/php82/etc/php82/environment.d/demonstration.conf
@@ -1,0 +1,1 @@
+production.conf

--- a/php/base/php83/etc/php83/environment.d/demo.conf
+++ b/php/base/php83/etc/php83/environment.d/demo.conf
@@ -1,0 +1,1 @@
+production.conf

--- a/php/base/php83/etc/php83/environment.d/demonstration.conf
+++ b/php/base/php83/etc/php83/environment.d/demonstration.conf
@@ -1,0 +1,1 @@
+production.conf


### PR DESCRIPTION
So that we avoid seeing errors and warnings on demo environments when doing training and demos.

Refs: OPS-9778