### PR TITLE
[OPS-9780] Fix nginx location for files for php images

### DIFF
--- a/php/php-k8s-v81/etc/nginx/apps/drupal/drupal.conf
+++ b/php/php-k8s-v81/etc/nginx/apps/drupal/drupal.conf
@@ -56,41 +56,16 @@ location / {
     }
 
     ## Trying to access private files directly returns a 404.
-    location ^~ /sites/.*/private/ {
+    location ~ "^/sites/.*/private/" {
         internal;
-    }
-
-    ## Location for public files. Avoid hitting Drupal on thye *production* env
-    ## if a file exists, but do pass it on otherwise, so stage_file_proxy can
-    ## fetch a file from production if needed.
-    location ^~ /sites/.*/files/ {
-        access_log off;
-        expires 30d;
-        ## No need to bleed constant updates. Send the all shebang in one
-        ## fell swoop.
-        tcp_nodelay off;
-
-        ## Set the OS file cache.
-        open_file_cache max=3000 inactive=120s;
-        open_file_cache_valid 45s;
-        open_file_cache_min_uses 2;
-        open_file_cache_errors off;
-
-        ## Location for aggregated css and js files under D 10.1. See:
-        ## https://www.drupal.org/node/2888767#nginx-php-fpm
-        location ^~ /sites/.*/files/(css|js)/ {
-            # Hit the original file *or* allow Drupal to aggregate.
-            try_files $uri @drupal;
-        }
-
-        ## Serve the file directly and fall back to drupal in case stage_file_proxy is needed.
-        try_files $uri @drupal-stage-file-proxy;
     }
 
     ## Location for public derivative images to avoid hitting Drupal for invalid
     ## image derivative paths or if the source image doesn't exist.
-    location ^~ /sites/.*/files/styles/ {
-
+    ##
+    ## Note: this needs to be before the public files regex because nginx stops
+    ## at the first found matching regex location.
+    location ~ "^/sites/.*/files/styles/" {
         ## Valid public derivative image paths.
         ## We store the source image path without the extra `.webp` extension
         ## present in the derivative so that we can check if the source image
@@ -118,6 +93,34 @@ location / {
 
         ## Simply return a 404 for unrecognized derivative image paths.
         return 404;
+    }
+
+    ## Location for public files. Avoid hitting Drupal on the *production* env
+    ## if a file exists, but do pass it on otherwise, so stage_file_proxy can
+    ## fetch a file from production if needed.
+    location ~ "^/sites/.*/files/" {
+        access_log off;
+        expires 30d;
+        ## No need to bleed constant updates. Send the all shebang in one
+        ## fell swoop.
+        tcp_nodelay off;
+
+        ## Set the OS file cache.
+        open_file_cache max=3000 inactive=120s;
+        open_file_cache_valid 45s;
+        open_file_cache_min_uses 2;
+        open_file_cache_errors off;
+
+        ## Location for aggregated css and js files under D 10.1. See:
+        ## https://www.drupal.org/node/2888767#nginx-php-fpm
+        location ~ "^/sites/.*/files/(css|js)/" {
+            # Hit the original file *or* allow Drupal to aggregate.
+            try_files $uri @drupal;
+        }
+
+        ## Serve the file directly and fall back to drupal in case
+        ## stage_file_proxy is needed.
+        try_files $uri @drupal-stage-file-proxy;
     }
 
     ## All static files will be served directly.

--- a/php/php-k8s-v82/etc/nginx/apps/drupal/drupal.conf
+++ b/php/php-k8s-v82/etc/nginx/apps/drupal/drupal.conf
@@ -56,41 +56,16 @@ location / {
     }
 
     ## Trying to access private files directly returns a 404.
-    location ^~ /sites/.*/private/ {
+    location ~ "^/sites/.*/private/" {
         internal;
-    }
-
-    ## Location for public files. Avoid hitting Drupal on thye *production* env
-    ## if a file exists, but do pass it on otherwise, so stage_file_proxy can
-    ## fetch a file from production if needed.
-    location ^~ /sites/.*/files/ {
-        access_log off;
-        expires 30d;
-        ## No need to bleed constant updates. Send the all shebang in one
-        ## fell swoop.
-        tcp_nodelay off;
-
-        ## Set the OS file cache.
-        open_file_cache max=3000 inactive=120s;
-        open_file_cache_valid 45s;
-        open_file_cache_min_uses 2;
-        open_file_cache_errors off;
-
-        ## Location for aggregated css and js files under D 10.1. See:
-        ## https://www.drupal.org/node/2888767#nginx-php-fpm
-        location ^~ /sites/.*/files/(css|js)/ {
-            # Hit the original file *or* allow Drupal to aggregate.
-            try_files $uri @drupal;
-        }
-
-        ## Serve the file directly and fall back to drupal in case stage_file_proxy is needed.
-        try_files $uri @drupal-stage-file-proxy;
     }
 
     ## Location for public derivative images to avoid hitting Drupal for invalid
     ## image derivative paths or if the source image doesn't exist.
-    location ^~ /sites/.*/files/styles/ {
-
+    ##
+    ## Note: this needs to be before the public files regex because nginx stops
+    ## at the first found matching regex location.
+    location ~ "^/sites/.*/files/styles/" {
         ## Valid public derivative image paths.
         ## We store the source image path without the extra `.webp` extension
         ## present in the derivative so that we can check if the source image
@@ -118,6 +93,34 @@ location / {
 
         ## Simply return a 404 for unrecognized derivative image paths.
         return 404;
+    }
+
+    ## Location for public files. Avoid hitting Drupal on the *production* env
+    ## if a file exists, but do pass it on otherwise, so stage_file_proxy can
+    ## fetch a file from production if needed.
+    location ~ "^/sites/.*/files/" {
+        access_log off;
+        expires 30d;
+        ## No need to bleed constant updates. Send the all shebang in one
+        ## fell swoop.
+        tcp_nodelay off;
+
+        ## Set the OS file cache.
+        open_file_cache max=3000 inactive=120s;
+        open_file_cache_valid 45s;
+        open_file_cache_min_uses 2;
+        open_file_cache_errors off;
+
+        ## Location for aggregated css and js files under D 10.1. See:
+        ## https://www.drupal.org/node/2888767#nginx-php-fpm
+        location ~ "^/sites/.*/files/(css|js)/" {
+            # Hit the original file *or* allow Drupal to aggregate.
+            try_files $uri @drupal;
+        }
+
+        ## Serve the file directly and fall back to drupal in case
+        ## stage_file_proxy is needed.
+        try_files $uri @drupal-stage-file-proxy;
     }
 
     ## All static files will be served directly.

--- a/php/php-k8s-v83/etc/nginx/apps/drupal/drupal.conf
+++ b/php/php-k8s-v83/etc/nginx/apps/drupal/drupal.conf
@@ -56,41 +56,16 @@ location / {
     }
 
     ## Trying to access private files directly returns a 404.
-    location ^~ /sites/.*/private/ {
+    location ~ "^/sites/.*/private/" {
         internal;
-    }
-
-    ## Location for public files. Avoid hitting Drupal on thye *production* env
-    ## if a file exists, but do pass it on otherwise, so stage_file_proxy can
-    ## fetch a file from production if needed.
-    location ^~ /sites/.*/files/ {
-        access_log off;
-        expires 30d;
-        ## No need to bleed constant updates. Send the all shebang in one
-        ## fell swoop.
-        tcp_nodelay off;
-
-        ## Set the OS file cache.
-        open_file_cache max=3000 inactive=120s;
-        open_file_cache_valid 45s;
-        open_file_cache_min_uses 2;
-        open_file_cache_errors off;
-
-        ## Location for aggregated css and js files under D 10.1. See:
-        ## https://www.drupal.org/node/2888767#nginx-php-fpm
-        location ^~ /sites/.*/files/(css|js)/ {
-            # Hit the original file *or* allow Drupal to aggregate.
-            try_files $uri @drupal;
-        }
-
-        ## Serve the file directly and fall back to drupal in case stage_file_proxy is needed.
-        try_files $uri @drupal-stage-file-proxy;
     }
 
     ## Location for public derivative images to avoid hitting Drupal for invalid
     ## image derivative paths or if the source image doesn't exist.
-    location ^~ /sites/.*/files/styles/ {
-
+    ##
+    ## Note: this needs to be before the public files regex because nginx stops
+    ## at the first found matching regex location.
+    location ~ "^/sites/.*/files/styles/" {
         ## Valid public derivative image paths.
         ## We store the source image path without the extra `.webp` extension
         ## present in the derivative so that we can check if the source image
@@ -118,6 +93,34 @@ location / {
 
         ## Simply return a 404 for unrecognized derivative image paths.
         return 404;
+    }
+
+    ## Location for public files. Avoid hitting Drupal on the *production* env
+    ## if a file exists, but do pass it on otherwise, so stage_file_proxy can
+    ## fetch a file from production if needed.
+    location ~ "^/sites/.*/files/" {
+        access_log off;
+        expires 30d;
+        ## No need to bleed constant updates. Send the all shebang in one
+        ## fell swoop.
+        tcp_nodelay off;
+
+        ## Set the OS file cache.
+        open_file_cache max=3000 inactive=120s;
+        open_file_cache_valid 45s;
+        open_file_cache_min_uses 2;
+        open_file_cache_errors off;
+
+        ## Location for aggregated css and js files under D 10.1. See:
+        ## https://www.drupal.org/node/2888767#nginx-php-fpm
+        location ~ "^/sites/.*/files/(css|js)/" {
+            # Hit the original file *or* allow Drupal to aggregate.
+            try_files $uri @drupal;
+        }
+
+        ## Serve the file directly and fall back to drupal in case
+        ## stage_file_proxy is needed.
+        try_files $uri @drupal-stage-file-proxy;
     }
 
     ## All static files will be served directly.


### PR DESCRIPTION
Refs: OPS-9780

This fixes the location for the private/public files. Nginx `^~` is a prefix match not a regex math so those types of locations with a `.*` component were never matched and the requests were passed to Drupal which looked like it worked.

Previously we had `location ^~ /sites/default/files` which was fine when we replaced `default` with  `.*` we actually broke those locations.

This PR changes the public/private files locations to regex ones: `^~ /sites/.*/files` --> `~ "^~/sites/.*/files"` and moves the `styles` location above the generic public files one because nginx stops at the first matching regex location.

This solves OPS-9780 notably.