### PR TITLE
feat: Refactor the bot detection rules to assume guilt.

### DIFF
--- a/php/php-k8s-v81/etc/nginx/ratelimit.conf
+++ b/php/php-k8s-v81/etc/nginx/ratelimit.conf
@@ -3,7 +3,7 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                1;   # The new default is what we assume you are a bot!
+        default                0;   # With the benefit of the doubt.
         ~*pingdom              0;   # Pingdom is a bot, but allowed.
         ~*elb-healthchecker    0;   # The AWS health check is allowed.
         ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
@@ -11,7 +11,7 @@ map $http_user_agent $isbot_ua {
         ~*0\.0\.0              1;   # Masking version? Bot.
         ""                     1;   # Empty UA? Bot!
         "-"                    1;   # No UA? probably a bot.
-        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
+        "~^[^/]*$"             1;   # If your UA contains no slash, you are most likely a bot.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v81/etc/nginx/ratelimit.conf
+++ b/php/php-k8s-v81/etc/nginx/ratelimit.conf
@@ -3,12 +3,15 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                0;
-        ~*pingdom              0;
-        ~*(bot|crawler|spider) 1;
-        ~*facebookexternalhit  1;
-        ""                     1;
-        "-"                    1;
+        default                1;   # The new default is what we assume you are a bot!
+        ~*pingdom              0;   # Pingdom is a bot, but allowed.
+        ~*elb-healthchecker    0;   # The AWS health check is allowed.
+        ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
+        ~*facebookexternalhit  1;   # Deffo a bot.
+        ~*0\.0\.0              1;   # Masking version? Bot.
+        ""                     1;   # Empty UA? Bot!
+        "-"                    1;   # No UA? probably a bot.
+        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v81/etc/nginx/ratelimit.conf.template
+++ b/php/php-k8s-v81/etc/nginx/ratelimit.conf.template
@@ -5,12 +5,15 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                0;
-        ~*pingdom              0;
-        ~*(bot|crawler|spider) 1;
-        ~*facebookexternalhit  1;
-        ""                     1;
-        "-"                    1;
+        default                1;   # The new default is what we assume you are a bot!
+        ~*pingdom              0;   # Pingdom is a bot, but allowed.
+        ~*elb-healthchecker    0;   # The AWS health check is allowed.
+        ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
+        ~*facebookexternalhit  1;   # Deffo a bot.
+        ~*0\.0\.0              1;   # Masking version? Bot.
+        ""                     1;   # Empty UA? Bot!
+        "-"                    1;   # No UA? probably a bot.
+        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v81/etc/nginx/ratelimit.conf.template
+++ b/php/php-k8s-v81/etc/nginx/ratelimit.conf.template
@@ -5,7 +5,7 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                1;   # The new default is what we assume you are a bot!
+        default                0;   # With the benefit of the doubt.
         ~*pingdom              0;   # Pingdom is a bot, but allowed.
         ~*elb-healthchecker    0;   # The AWS health check is allowed.
         ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
@@ -13,7 +13,7 @@ map $http_user_agent $isbot_ua {
         ~*0\.0\.0              1;   # Masking version? Bot.
         ""                     1;   # Empty UA? Bot!
         "-"                    1;   # No UA? probably a bot.
-        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
+        "~^[^/]*$"             1;   # If your UA contains no slash, you are most likely a bot.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v82/etc/nginx/ratelimit.conf
+++ b/php/php-k8s-v82/etc/nginx/ratelimit.conf
@@ -3,7 +3,7 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                1;   # The new default is what we assume you are a bot!
+        default                0;   # With the benefit of the doubt.
         ~*pingdom              0;   # Pingdom is a bot, but allowed.
         ~*elb-healthchecker    0;   # The AWS health check is allowed.
         ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
@@ -11,7 +11,7 @@ map $http_user_agent $isbot_ua {
         ~*0\.0\.0              1;   # Masking version? Bot.
         ""                     1;   # Empty UA? Bot!
         "-"                    1;   # No UA? probably a bot.
-        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
+        "~^[^/]*$"             1;   # If your UA contains no slash, you are most likely a bot.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v82/etc/nginx/ratelimit.conf
+++ b/php/php-k8s-v82/etc/nginx/ratelimit.conf
@@ -3,12 +3,15 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                0;
-        ~*pingdom              0;
-        ~*(bot|crawler|spider) 1;
-        ~*facebookexternalhit  1;
-        ""                     1;
-        "-"                    1;
+        default                1;   # The new default is what we assume you are a bot!
+        ~*pingdom              0;   # Pingdom is a bot, but allowed.
+        ~*elb-healthchecker    0;   # The AWS health check is allowed.
+        ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
+        ~*facebookexternalhit  1;   # Deffo a bot.
+        ~*0\.0\.0              1;   # Masking version? Bot.
+        ""                     1;   # Empty UA? Bot!
+        "-"                    1;   # No UA? probably a bot.
+        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v82/etc/nginx/ratelimit.conf.template
+++ b/php/php-k8s-v82/etc/nginx/ratelimit.conf.template
@@ -5,12 +5,15 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                0;
-        ~*pingdom              0;
-        ~*(bot|crawler|spider) 1;
-        ~*facebookexternalhit  1;
-        ""                     1;
-        "-"                    1;
+        default                1;   # The new default is what we assume you are a bot!
+        ~*pingdom              0;   # Pingdom is a bot, but allowed.
+        ~*elb-healthchecker    0;   # The AWS health check is allowed.
+        ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
+        ~*facebookexternalhit  1;   # Deffo a bot.
+        ~*0\.0\.0              1;   # Masking version? Bot.
+        ""                     1;   # Empty UA? Bot!
+        "-"                    1;   # No UA? probably a bot.
+        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v82/etc/nginx/ratelimit.conf.template
+++ b/php/php-k8s-v82/etc/nginx/ratelimit.conf.template
@@ -5,7 +5,7 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                1;   # The new default is what we assume you are a bot!
+        default                0;   # With the benefit of the doubt.
         ~*pingdom              0;   # Pingdom is a bot, but allowed.
         ~*elb-healthchecker    0;   # The AWS health check is allowed.
         ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
@@ -13,7 +13,7 @@ map $http_user_agent $isbot_ua {
         ~*0\.0\.0              1;   # Masking version? Bot.
         ""                     1;   # Empty UA? Bot!
         "-"                    1;   # No UA? probably a bot.
-        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
+        "~^[^/]*$"             1;   # If your UA contains no slash, you are most likely a bot.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v83/etc/nginx/ratelimit.conf
+++ b/php/php-k8s-v83/etc/nginx/ratelimit.conf
@@ -3,7 +3,7 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                1;   # The new default is what we assume you are a bot!
+        default                0;   # With the benefit of the doubt.
         ~*pingdom              0;   # Pingdom is a bot, but allowed.
         ~*elb-healthchecker    0;   # The AWS health check is allowed.
         ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
@@ -11,7 +11,7 @@ map $http_user_agent $isbot_ua {
         ~*0\.0\.0              1;   # Masking version? Bot.
         ""                     1;   # Empty UA? Bot!
         "-"                    1;   # No UA? probably a bot.
-        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
+        "~^[^/]*$"             1;   # If your UA contains no slash, you are most likely a bot.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v83/etc/nginx/ratelimit.conf
+++ b/php/php-k8s-v83/etc/nginx/ratelimit.conf
@@ -3,12 +3,15 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                0;
-        ~*pingdom              0;
-        ~*(bot|crawler|spider) 1;
-        ~*facebookexternalhit  1;
-        ""                     1;
-        "-"                    1;
+        default                1;   # The new default is what we assume you are a bot!
+        ~*pingdom              0;   # Pingdom is a bot, but allowed.
+        ~*elb-healthchecker    0;   # The AWS health check is allowed.
+        ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
+        ~*facebookexternalhit  1;   # Deffo a bot.
+        ~*0\.0\.0              1;   # Masking version? Bot.
+        ""                     1;   # Empty UA? Bot!
+        "-"                    1;   # No UA? probably a bot.
+        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v83/etc/nginx/ratelimit.conf.template
+++ b/php/php-k8s-v83/etc/nginx/ratelimit.conf.template
@@ -5,12 +5,15 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                0;
-        ~*pingdom              0;
-        ~*(bot|crawler|spider) 1;
-        ~*facebookexternalhit  1;
-        ""                     1;
-        "-"                    1;
+        default                1;   # The new default is what we assume you are a bot!
+        ~*pingdom              0;   # Pingdom is a bot, but allowed.
+        ~*elb-healthchecker    0;   # The AWS health check is allowed.
+        ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
+        ~*facebookexternalhit  1;   # Deffo a bot.
+        ~*0\.0\.0              1;   # Masking version? Bot.
+        ""                     1;   # Empty UA? Bot!
+        "-"                    1;   # No UA? probably a bot.
+        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
 }
 
 ## Set a limit zone based on the bot status.

--- a/php/php-k8s-v83/etc/nginx/ratelimit.conf.template
+++ b/php/php-k8s-v83/etc/nginx/ratelimit.conf.template
@@ -5,7 +5,7 @@ limit_req_status 429;
 
 ## Determine if this is a bot request via the user-agent string.
 map $http_user_agent $isbot_ua {
-        default                1;   # The new default is what we assume you are a bot!
+        default                0;   # With the benefit of the doubt.
         ~*pingdom              0;   # Pingdom is a bot, but allowed.
         ~*elb-healthchecker    0;   # The AWS health check is allowed.
         ~*(bot|crawler|spider) 1;   # You are scrapers, thus bots.
@@ -13,7 +13,7 @@ map $http_user_agent $isbot_ua {
         ~*0\.0\.0              1;   # Masking version? Bot.
         ""                     1;   # Empty UA? Bot!
         "-"                    1;   # No UA? probably a bot.
-        ~\/                    0;   # If your UA contains a slash, you may be human. This implies UAs *without* a slash are all bots.
+        "~^[^/]*$"             1;   # If your UA contains no slash, you are most likely a bot.
 }
 
 ## Set a limit zone based on the bot status.


### PR DESCRIPTION
Everyone is a bot, UNLESS their user-agent does not contain key words or version 0.0.0 and contains a slash.

Sadly this change is needed, because nginx regexes do not support not-match syntax and we definitely want to catch random-string user-agents.

Refs: OPS-10762